### PR TITLE
stream_aligner: normalize search behaviours in indexes, and the meaning of bounds in intervals

### DIFF
--- a/lib/pocolog/data_reader.rb
+++ b/lib/pocolog/data_reader.rb
@@ -362,13 +362,13 @@ module Pocolog
                           end
             end_index = if end_index.is_a? Time
                             if interval.last < end_index
-                                size-1
+                                size
                             else
                                 stream_index.sample_number_by_time(end_index)
                             end
                         else
                             if end_index >= size
-                                size-1
+                                size
                             else
                                 end_index
                             end
@@ -385,7 +385,7 @@ module Pocolog
                 data = logfile.data(data_header, data_buffer)
                 stream.write_raw(data_header.rt,data_header.lg,data)
                 counter += 1
-            end while advance && counter <= max
+            end while advance && counter < max
             counter
         end
 
@@ -398,17 +398,9 @@ module Pocolog
             if start_index.is_a? Time
                 interval = time_interval
                 return unless interval.first
-                if start_index <= interval.last && start_index <= end_index && end_index >= interval.first
-                    true
-                else
-                    false
-                end
+                start_index <= interval.last && start_index <= end_index && end_index >= interval.first
             else
-                if start_index < size && start_index <= end_index && end_index >= 0
-                    true
-                else
-                    false
-                end
+                start_index < size && start_index <= end_index && end_index >= 0
             end
         end
     end

--- a/lib/pocolog/file.rb
+++ b/lib/pocolog/file.rb
@@ -947,6 +947,11 @@ module Pocolog
                 Logfiles.write_data_block(wio, stream.index, rt, lg, compress, data)
             end
 	end
+
+        # Creates a stream aligner on all streams of this logfile
+        def stream_aligner(use_rt = false)
+            StreamAligner.new(use_rt, *streams.compact)
+        end
     end
 
     # Returns the stream called +stream_name+ from file

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -361,6 +361,8 @@ module Pocolog
                     stream_end_index, s)
                 next if first_stream_pos == last_stream_pos
 
+                index = 0
+                number_of_samples = stream_end_index-stream_start_index+1
                 stream_output = output.create_stream(s.name, s.type)
                 result = s.copy_to(first_stream_pos,last_stream_pos,stream_output) do |i|
                     if block

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -1,5 +1,3 @@
-require 'rbtree'
-
 module Pocolog
     class OutOfBounds < Exception;end
     class StreamAligner
@@ -26,31 +24,40 @@ module Pocolog
         # The index of the current sample
         attr_reader :sample_index
 
-        #global index for the first and last sample of the streams
-        attr_reader :global_pos_last_sample
+        # A per-stream mapping from the stream index to the global position of
+        # the last of this stream's samples
+        #
+        # @see first_sample_pos
         attr_reader :global_pos_first_sample
 
+        # A per-stream mapping from the stream index to the global position of
+        # the first of this stream's samples
+        #
+        # @see last_sample_pos
+        attr_reader :global_pos_last_sample
+
+        # The full aligned index
+        #
+        # This is a mapping from a global position in the aligned stream to
+        # information about the sample at that stream
+        #
+        # @return [Array<IndexEntry>]
         attr_reader :full_index
 
-        attr_reader :time_interval      #time interval for which samples are avialable
-
-	#The samples contained in the StreamAligner
-	#Or in other words the sum over the sizes from all contained streams
-	attr_reader :size
+        # The time of the first and last samples in the stream
+        #
+        # @return [(Time,Time)]
+        attr_reader :time_interval
 	
-	# Contains whether a stream has replayed a sample 
-	# since the last {seek} (or {rewind})
-	attr_reader :stream_has_sample
-	
-	def initialize(use_rt = false, *streams)
-	    @use_sample_time = use_rt == :use_sample_time
-	    @use_rt  = use_rt
+        def initialize(use_rt = false, *streams)
+            @use_sample_time = use_rt == :use_sample_time
+            @use_rt  = use_rt
             @global_pos_first_sample = Hash.new
             @global_pos_last_sample = Hash.new
             @streams = streams
             @stream_state = Array.new
 
-	    @sample_index = -1
+            @sample_index = -1
             build_index(streams)
             rewind
         end
@@ -59,31 +66,34 @@ module Pocolog
         #
         # @return [Time]
         def time
-            if entry = full_index[@sample_index]
+            if entry = full_index[sample_index]
                 StreamIndex.time_from_internal(entry.time, base_time)
             end
         end
 
 	# Tests whether reading the next sample will return something
         #
-        # If {eof?} returns true, {advance} and {step} are guaranteed to return
+        # If {eof?} returns true, {#advance} and {#step} are guaranteed to return
         # nil if called.
         def eof?
 	    sample_index >= size - 1
         end
 
         # Rewinds the stream aligner to the position before the first sample
+        #
+        # I.e. calling {#next} after {#rewind} would read the first sample
 	def rewind
 	    @sample_index = -1
             nil
         end
 
-        IndexEntry = Struct.new :time, :position_in_stream, :stream_number, :position_global
+        IndexEntry = Struct.new :time, :stream_number, :position_in_stream, :position_global
 
-        # This method builds a composite index based on the stream index. 
-	# Therefor it iterates over all streams and builds an index sample
-	# every INDEX_DENSITY samples.
-	# The Layout is [global_pos, [stream1 pos, stream2_pos...]]
+        # @api private
+        #
+        # This method builds {#full_index} and fills in some of the global
+        # attributes based on the information contained in the underlying
+        # streams
         def build_index(streams)
 	    @size = streams.inject(0) { |s, stream| s + stream.size }
 	    Pocolog.info("got #{streams.size} streams with #{size} samples")
@@ -95,18 +105,19 @@ module Pocolog
 
             full_index = Array.new
             streams.each_with_index do |stream, i|
-                base_time_offset = stream.stream_index.base_time - base_time
-                stream.stream_index.time_to_position_map.each_with_index do |time, position|
-                    full_index << [time + base_time_offset, position, i]
+                stream.stream_index.base_time = base_time
+                stream.stream_index.time_to_position_map.each do |time, position|
+                    full_index << [time, i, position]
                 end
             end
 
             Pocolog.info "concatenated indexes in #{"%.2f" % [Time.now - tic]} seconds"
             full_index.sort!
             @full_index = full_index.each_with_index.map do |entry, position_global|
-                global_pos_first_sample[entry[2]] ||= position_global
-                global_pos_last_sample[entry[2]] = position_global
-                IndexEntry.new(*entry, position_global)
+                entry = IndexEntry.new(*entry, position_global)
+                global_pos_first_sample[entry.stream_number] ||= position_global
+                global_pos_last_sample[entry.stream_number] = position_global
+                entry
             end
             if full_index.size != size
                 raise
@@ -115,14 +126,26 @@ module Pocolog
             Pocolog.info "built index in #{"%.2f" % [Time.now - tic]} seconds"
         end
 	
-	def seek(pos)
+        # Seek at the given position or time
+        #
+        # @overload seek(pos, read_data = true)
+        #   (see seek_to_pos)
+        # @overload seek(time, read_data = true)
+        #   (see seek_to_time)
+	def seek(pos, read_data = true)
 	    if pos.kind_of?(Time)
-		seek_to_time(pos)
+		seek_to_time(pos, read_data)
 	    else
-		seek_to_pos(pos)
+		seek_to_pos(pos, read_data)
 	    end
 	end
 	
+        # Seek to the first sample after the given time
+        #
+        # @param [Time] time the reference time
+        # @param [Boolean] read_data whether the sample itself should be read or not
+        # @return [(Integer,Time[,Typelib::Type])] the stream index, sample time
+        #   and the sample itself if read_data is true
 	def seek_to_time(time, read_data = true)
             if(time < time_interval[0] || time > time_interval[1]) 
                 raise RangeError, "#{time} is out of bounds valid interval #{time_interval[0]} to #{time_interval[1]}"
@@ -130,10 +153,30 @@ module Pocolog
 	    
             target_time = StreamIndex.time_to_internal(time, base_time)
 	    entry = @full_index.bsearch { |entry| entry.time >= target_time }
-            seek_to_index_entry(entry)
+            seek_to_index_entry(entry, read_data)
 	end
 
-        # This is a private helper for {seek_to_time} and {seek_to_pos}
+        # Seeks to the sample whose global position is pos
+        #
+        # @param [Integer] pos the targetted global position
+        # @param [Boolean] read_data whether the sample itself should be read or not
+        # @return [(Integer,Time[,Typelib::Type])] the stream index, sample time
+        #   and the sample itself if read_data is true
+        def seek_to_pos(pos, read_data = true)
+            if pos < 0 || pos > size
+                raise OutOfBounds, "#{pos} is out of bounds [0..#{size}]."
+            end
+
+            seek_to_index_entry(@full_index[pos], read_data)
+        end
+
+        # @api private
+        #
+        # This is a private helper for {seek_to_time} and {seek_to_pos}. It
+        # seeks the stream aligner to the given global sample
+        #
+        # @param [IndexEntry] entry index entry of the global sample we want to
+        #   seek to
         def seek_to_index_entry(entry, read_data = true)
             if !entry
                 @sample_index = size
@@ -150,19 +193,23 @@ module Pocolog
             end
         end
 
-        # Seeks to the sample whose global position is pos
+        # Return the stream object at the given stream index
         #
-        # @param [Integer] pos the targetted global position
-        # @param [Boolean] read_data whether the method should read the sample
-        #   and return it, or only seek
-        def seek_to_pos(pos, read_data = true)
-            if pos < 0 || pos > size
-                raise OutOfBounds, "#{pos} is out of bounds [0..#{size}]."
-            end
+        # @param [Integer] stream_idx
+        # @return [DataStream]
+        def stream_by_index(stream_idx)
+            @streams[stream_idx]
+        end
 
-            seek_to_index_entry(@full_index[pos])
+        # Returns the stream index for the given stream
+        def stream_index_for_stream(stream)
+            streams.index(stream)
         end
             
+        # Returns the stream index of the stream with this name
+        #
+        # @param [String] name
+        # @return [Integer,nil]
         def stream_index_for_name(name)
             streams.each_with_index do |s,i|
                 if(s.name == name)
@@ -172,25 +219,30 @@ module Pocolog
             return nil 
         end
         
+        # Returns the stream index of the stream whose type has this name
+        #
+        # @param [String] name
+        # @return [Integer,nil]
+        # @raise [ArgumentError] if more than one stream has this type
         def stream_index_for_type(name)
             stream = nil
             streams.each_with_index do |s,i|
                 if(s.type_name == name)
-                    raise "There exists more than one stream with type #{name}" if stream
+                    raise ArgumentError, "There exists more than one stream with type #{name}" if stream
                     stream = i
                 end
             end
             stream
         end
 
-        # call-seq:
-        #   joint_stream.step => updated_stream_index, time, data
-        #
-        # Advances one step in the joint stream, an returns the index of the
+        # Advances one step in the joint stream, and returns the index of the
         # updated stream as well as the time and the data sample
         #
         # The associated data sample can also be retrieved by
         # single_data(stream_idx)
+        #
+        # @return [(Integer,Time,Typelib::Type)]
+        # @see advance
         def step
             stream_idx, time = advance
             if stream_idx
@@ -198,15 +250,15 @@ module Pocolog
             end
         end
 
-        # call-seq:
-        #  joint_stream.advance => updated_stream_index, time 
-        #
-        # Advances one step in the joint stream, and returns the index of
-        # the update stream as well as the time but does not encode the data sample_index
-        # like step or next does
+        # Advances one step in the joint stream, and returns the index of the
+        # update stream as well as the time but does not decode the data
+        # sample_index like {#step} or {#next} does
         #
         # The associated data sample can then be retrieved by
         # single_data(stream_idx)
+        #
+        # @return [(Integer,Time)]
+        # @see step
         def advance
 	    if eof?
 		@sample_index = size
@@ -217,7 +269,9 @@ module Pocolog
         end
 
         # Decrements one step in the joint stream, an returns the index of the
-        # updated stream as well as the time.
+        # updated stream, its time as well as the sample data
+        #
+        # @return [(Integer,Time,Typelib::Type)]
         def step_back
 	    if @sample_index == 0
 		@sample_index = -1
@@ -227,12 +281,27 @@ module Pocolog
 	    seek_to_pos(sample_index - 1)
         end
 
-        # call-seq:
-        #   aligner.next => time, time, [stream_index, data]
-        #
         # Defined for compatibility with DataStream#next
+        #
+        # Goes one sample further and returns the sample's logical and real
+        # times as well as the stream index and the sample data
+        #
+        # @return [(Time,Time,(Integer,Typelib::Type)),nil]
         def next
             stream_index, time, data = step
+            if stream_index
+                return time, time, [stream_index, data]
+            end
+        end
+
+        # Defined for compatibility with DataStream#previous
+        #
+        # Goes back one sample and returns the sample's logical and real
+        # times as well as the stream index and the sample data
+        #
+        # @return [(Time,Time,(Integer,Typelib::Type)),nil]
+        def previous
+            stream_index, time, data = step_back
             if stream_index
                 return time, time, [stream_index, data]
             end
@@ -266,42 +335,31 @@ module Pocolog
             end
         end
 
-        # Defined for backward compatibility with DataStream#previous
-        def previous
-            stream_index, time, data = step_back
-            if stream_index
-                return time, time, [stream_index, data]
-            end
-        end
-
         # exports all streams to a new log file 
         # if no start and end index is given all data are exported
         # otherwise the data are truncated according to the given global indexes 
         # 
         # the block is called for each sample to update a custom progress bar if the block
         # returns 1 the export is canceled
-        def export_to_file(file,start_index=0,end_index=nil,&block)
-            end_index ||= size - 1
-
+        def export_to_file(file,start_index=0,end_index=size,&block)
             output = Pocolog::Logfiles.create(file)
-            streams.each_with_index do |s|
-                first_index = first_sample_pos(s)
-                last_index  = last_sample_pos(s)
+            streams.each do |s|
+                stream_start_index = first_sample_pos(s)
+                stream_end_index  = last_sample_pos(s) + 1
                 # Ignore the stream if it is empty
-                next if !start_index
+                next if !stream_start_index
                 # Ignore the stream if there are no samples intersecting with
                 # the required interval
-                next if start_index >= last_index || end_index <= first_index
+                next if start_index >= stream_end_index || end_index <= stream_start_index
 
-                stream_start_index = [start_index, first_index].max
-                stream_end_index   = [end_index, last_index].min
+                stream_start_index = [start_index, stream_start_index].max
+                stream_end_index   = [end_index, stream_end_index].min
                 
-                first_stream_pos = find_first_stream_sample_after(
+                first_stream_pos = find_first_stream_sample_at_or_after(
                     stream_start_index, s)
-                last_stream_pos  = find_first_stream_sample_after(
-                    stream_end_index, s) || (last_index + 1)
-                last_stream_pos = last_stream_pos - 1
-                next if first_stream_pos >= last_stream_pos
+                last_stream_pos  = find_first_stream_sample_at_or_after(
+                    stream_end_index, s)
+                next if first_stream_pos == last_stream_pos
 
                 stream_output = output.create_stream(s.name, s.type)
                 result = s.copy_to(first_stream_pos,last_stream_pos,stream_output) do |i|
@@ -315,32 +373,69 @@ module Pocolog
             output.close
         end
 
-        def find_first_stream_sample_after(position_global, stream)
-            # Find the time of the first sample after position_global in stream
-            entry = full_index[position_global]
-            time = entry.time
-            stream_index = stream.stream_index
-            stream_pos  = stream_index.sample_number_by_time(time)
-            stream_time = stream_index.time_by_sample_number(stream_pos)
-            stream_time = StreamIndex.time_to_internal(stream_time, base_time)
-            if time < stream_time
-                return stream_pos
-            else
-                # We have to check whether the sample is before or after
-                # position_global and act accordingly
-                stream_number = streams.index_of(stream)
-                while entry && (entry.time == stream_time)
-                    if entry.stream_number == stream_number && entry.position_in_stream == stream_pos
-                        return stream_pos
-                    end
-                    entry = full_index[position_global += 1]
-                end
-                if entry
-                    stream_pos + 1
-                else
-                    return
-                end
+        # Returns the stream-local index of the first sample that is either at
+        # or just after the given global position
+        #
+        # @param [Integer] position_global a global position
+        # @param [DataStream] stream the data stream
+        def find_first_stream_sample_at_or_after(position_global, stream)
+            if !(entry = full_index[position_global])
+                return stream.size
             end
+
+            stream_number = stream_index_for_stream(stream)
+            if entry.stream_number == stream_number
+                return entry.position_in_stream
+            end
+
+            find_first_stream_sample_after(position_global, stream)
+        end
+
+        # Returns the stream-local index of the first sample strictly after the
+        # sample at the given global position
+        #
+        # @param [Integer] position_global a global position
+        # @param [DataStream] stream the data stream
+        def find_first_stream_sample_after(position_global, stream)
+            if !(entry = full_index[position_global])
+                return stream.size
+            end
+
+            stream_number = stream_index_for_stream(stream)
+
+            # First things first, if entry is a sample of stream, we just have
+            # to go forward by one
+            if entry.stream_number == stream_number
+                return entry.position_in_stream + 1
+            end
+
+            # Otherwise, we need to search in the stream
+            time  = entry.time
+            search_pos = stream.stream_index.sample_number_by_internal_time(time)
+            if search_pos == stream.size
+                return search_pos
+            end
+
+            # If the sample we found has the same time than the entry at
+            # position_global, We now have to figure out whether it is before or
+            # after position global
+            #
+            # We do a linear search in all samples that have the same time than
+            # the reference time. This basically assumes that you don't have a
+            # million samples with the same time. I believe it fair.
+            search_time = stream.stream_index.internal_time_by_sample_number(search_pos)
+            if search_time != time
+                return search_pos
+            end
+
+            stream_number == stream_index_for_stream(stream)
+            while entry && entry.time == time
+                if entry.stream_number == stream_number
+                    return entry.position_in_stream
+                end
+                entry = @full_index[position_global += 1]
+            end
+            return search_pos + 1
         end
 
         # Returns the global sample position of the first sample
@@ -349,8 +444,8 @@ module Pocolog
         # @param [Integer,DataStream] the stream
         # @return [nil,Integer]
         def first_sample_pos(stream)
-            if !stream.kind_of?(DataStream)
-                stream = streams[stream]
+            if stream.kind_of?(DataStream)
+                stream = streams.index(stream)
             end
             @global_pos_first_sample[stream] 
         end
@@ -361,8 +456,8 @@ module Pocolog
         # @param [Integer,DataStream] the stream
         # @return [nil,Integer]
         def last_sample_pos(stream)
-            if !stream.kind_of?(DataStream)
-                stream = streams[stream]
+            if stream.kind_of?(DataStream)
+                stream = streams.index(stream)
             end
             @global_pos_last_sample[stream]
         end
@@ -392,12 +487,25 @@ module Pocolog
         # Returns the current data sample for the given stream index
 	# note stream index is the index of the data stream, not the 
 	# search index !
+        #
+        # @param [Integer] index index of the stream
+        # @param [Typelib::Type,nil] sample if given, the sample will be decoded
+        #   in this object instead of creating a new one
+        # @return [Object,nil]
         def single_data(index, sample = nil)
             if raw = single_raw_data(index, sample)
                 return Typelib.to_ruby(raw)
             end
         end
 
+        # Returns the current raw data sample for the given stream index
+	# note stream index is the index of the data stream, not the 
+	# search index !
+        #
+        # @param [Integer] index index of the stream
+        # @param [Typelib::Type,nil] sample if given, the sample will be decoded
+        #   in this object instead of creating a new one
+        # @return [Typelib::Type]
         def single_raw_data(index, sample = nil)
             stream, position = sample_info(index)
             if stream
@@ -405,11 +513,15 @@ module Pocolog
 	    end
         end
 
-        def stream_by_index(stream_idx)
-            @streams[stream_idx]
-        end
-
+        # Enumerate all samples in this stream
+        #
+        # @param [Boolean] do_rewind whether {#rewind} should be called first
+        # @yieldparam [Integer] stream_idx the stream in which the sample is
+        #   contained
+        # @yieldparam [Time] time the stream time
+        # @yieldparam [Object] sample the sample itself
         def each(do_rewind = true)
+            return enum_for(__method__, do_rewind) if !block_given?
             if do_rewind
                 rewind
             end

--- a/test/test_stream_aligner2.rb
+++ b/test/test_stream_aligner2.rb
@@ -104,17 +104,17 @@ class TC_StreamAligner2 < Minitest::Test
         @stream.export_to_file("export2.log",30)
         @stream.export_to_file("export3.log",90,109)
 
-        logfile2 = Pocolog::Logfiles.open('export1.log')
+        logfile2 = Pocolog::Logfiles.open('export1.log.0.log')
         stream2  = Pocolog::StreamAligner.new(false, logfile2.stream('all'), logfile2.stream('other'))
         assert_equal 200, stream2.size
         logfile2.close
 
-        logfile2 = Pocolog::Logfiles.open('export2.log')
+        logfile2 = Pocolog::Logfiles.open('export2.log.0.log')
         stream2  = Pocolog::StreamAligner.new(false, logfile2.stream('all'), logfile2.stream('other'))
         assert_equal 170, stream2.size
         logfile2.close
 
-        logfile2 = Pocolog::Logfiles.open('export3.log')
+        logfile2 = Pocolog::Logfiles.open('export3.log.0.log')
         stream2  = Pocolog::StreamAligner.new(false, logfile2.stream('all'), logfile2.stream('other'))
         assert_equal 20, stream2.size
 
@@ -138,3 +138,4 @@ class TC_StreamAligner2 < Minitest::Test
         end
     end
 end
+


### PR DESCRIPTION
This commit moves the stream aligner in a [min, max[ interpretation of intervals,
which is really really so much easier to handle. In particular, it
behaves much better when searching for a sample around a value, since
there is an easy past-the-end value (size) while there is none for
a last-sample-before behaviour (-1 ???)

It also tries to clear up some related unit tests, and add much needed documentation