### PR TITLE
aligner: accept empty streams

### DIFF
--- a/lib/pocolog.rb
+++ b/lib/pocolog.rb
@@ -21,7 +21,7 @@ module Pocolog
 
     # true if this machine is big endian
     def self.big_endian?
-	"LAAS".unpack('L').pack('N') == "LAAS"
+        "LAAS".unpack('L').pack('N') == "LAAS"
     end
 
     STREAM_BLOCK           = 1

--- a/lib/pocolog/convert.rb
+++ b/lib/pocolog/convert.rb
@@ -1,128 +1,128 @@
 
 module Pocolog
     class Logfiles
-	def self.write_prologue(to_io, big_endian = nil)
-	    to_io.write(MAGIC)
-	    if big_endian.nil?
-		big_endian = Pocolog.big_endian?
-	    end
-	    to_io.write(*[FORMAT_VERSION, big_endian ? 1 : 0].pack('xVV'))
-	end
+        def self.write_prologue(to_io, big_endian = nil)
+            to_io.write(MAGIC)
+            if big_endian.nil?
+                big_endian = Pocolog.big_endian?
+            end
+            to_io.write(*[FORMAT_VERSION, big_endian ? 1 : 0].pack('xVV'))
+        end
 
-	def self.copy_block(block_info, from_io, to_io, buffer)
-	    # copy the block as-is
-	    from_io.seek(block_info.pos)
-	    buffer = from_io.read(BLOCK_HEADER_SIZE + block_info.payload_size, buffer)
+        def self.copy_block(block_info, from_io, to_io, buffer)
+            # copy the block as-is
+            from_io.seek(block_info.pos)
+            buffer = from_io.read(BLOCK_HEADER_SIZE + block_info.payload_size, buffer)
             if block_given?
                 buffer = yield(buffer)
             end
-	    to_io.write(buffer)
-	end
+            to_io.write(buffer)
+        end
 
-	# Converts a version 1 logfile. Modifications:
-	# * no prologue
-	# * no compressed flag on data blocks
-	# * time was written as [type, sec, usec, padding], with each
-	#   field a 32-bit integer
-	def self.from_version_1(from, to_io, big_endian)
-	    write_prologue(to_io, big_endian)
-	    from_io = from.rio
+        # Converts a version 1 logfile. Modifications:
+        # * no prologue
+        # * no compressed flag on data blocks
+        # * time was written as [type, sec, usec, padding], with each
+        #   field a 32-bit integer
+        def self.from_version_1(from, to_io, big_endian)
+            write_prologue(to_io, big_endian)
+            from_io = from.rio
 
-	    buffer = ""
-	    uncompressed = [0].pack('C')
-	    from.each_block(true, false) do |block_info|
-		if block_info.type == STREAM_BLOCK
-		    copy_block(block_info, from_io, to_io, buffer)
-		elsif block_info.type == CONTROL_BLOCK
-		    # remove the fields in time structure
-		    to_io.write([block_info.type, block_info.index, block_info.payload_size - 16].pack('CxvV'))
-		    from_io.seek(block_info.pos + BLOCK_HEADER_SIZE + 4)
-		    to_io.write(from_io.read(8))
-		    from_io.seek(4, IO::SEEK_CUR)
-		    to_io.write(from_io.read(1))
-		    from_io.seek(4, IO::SEEK_CUR)
-		    to_io.write(from_io.read(8))
-		else
-		    size_offset = - 16 + 1
+            buffer = ""
+            uncompressed = [0].pack('C')
+            from.each_block(true, false) do |block_info|
+                if block_info.type == STREAM_BLOCK
+                    copy_block(block_info, from_io, to_io, buffer)
+                elsif block_info.type == CONTROL_BLOCK
+                    # remove the fields in time structure
+                    to_io.write([block_info.type, block_info.index, block_info.payload_size - 16].pack('CxvV'))
+                    from_io.seek(block_info.pos + BLOCK_HEADER_SIZE + 4)
+                    to_io.write(from_io.read(8))
+                    from_io.seek(4, IO::SEEK_CUR)
+                    to_io.write(from_io.read(1))
+                    from_io.seek(4, IO::SEEK_CUR)
+                    to_io.write(from_io.read(8))
+                else
+                    size_offset = - 16 + 1
 
-		    to_io.write([block_info.type, block_info.index, block_info.payload_size + size_offset].pack('CxvV'))
-		    from_io.seek(block_info.pos + BLOCK_HEADER_SIZE + 4)
-		    to_io.write(from_io.read(8))
-		    from_io.seek(8, IO::SEEK_CUR)
-		    to_io.write(from_io.read(8))
-		    from_io.seek(4, IO::SEEK_CUR)
-		    to_io.write(from_io.read(4))
-		    to_io.write(uncompressed)
-		    from_io.read(block_info.payload_size - (DATA_HEADER_SIZE - size_offset), buffer)
-		    to_io.write(buffer)
-		end
-	    end
-	end
+                    to_io.write([block_info.type, block_info.index, block_info.payload_size + size_offset].pack('CxvV'))
+                    from_io.seek(block_info.pos + BLOCK_HEADER_SIZE + 4)
+                    to_io.write(from_io.read(8))
+                    from_io.seek(8, IO::SEEK_CUR)
+                    to_io.write(from_io.read(8))
+                    from_io.seek(4, IO::SEEK_CUR)
+                    to_io.write(from_io.read(4))
+                    to_io.write(uncompressed)
+                    from_io.read(block_info.payload_size - (DATA_HEADER_SIZE - size_offset), buffer)
+                    to_io.write(buffer)
+                end
+            end
+        end
 
-	def self.to_new_format(from_io, to_io, big_endian = nil)
-	    from = Logfiles.new(from_io)
-	    from.read_prologue
+        def self.to_new_format(from_io, to_io, big_endian = nil)
+            from = Logfiles.new(from_io)
+            from.read_prologue
 
-	rescue MissingPrologue
-	    # This is format version 1. Need either --little-endian or --big-endian
-	    if big_endian.nil?
-		raise "#{from_io.path} looks like a v1 log file. You must specify either --little-endian or --big-endian"
-	    end
-	    puts "#{from_io.path}: format v1 in #{big_endian ? "big endian" : "little endian"}"
-	    from_version_1(from, to_io, big_endian)
+        rescue MissingPrologue
+            # This is format version 1. Need either --little-endian or --big-endian
+            if big_endian.nil?
+                raise "#{from_io.path} looks like a v1 log file. You must specify either --little-endian or --big-endian"
+            end
+            puts "#{from_io.path}: format v1 in #{big_endian ? "big endian" : "little endian"}"
+            from_version_1(from, to_io, big_endian)
 
-	rescue ObsoleteVersion
-	end
-	
-	def self.compress(from_io, to_io)
-	    from = Logfiles.new(from_io)
-	    from.read_prologue
-	    write_prologue(to_io, from.endian_swap ^ Pocolog.big_endian?)
+        rescue ObsoleteVersion
+        end
+        
+        def self.compress(from_io, to_io)
+            from = Logfiles.new(from_io)
+            from.read_prologue
+            write_prologue(to_io, from.endian_swap ^ Pocolog.big_endian?)
 
-	    compressed = [1].pack('C')
-	    buffer = "".encode('BINARY')
-	    from.each_block(true) do |block_info|
-		if block_info.type != DATA_BLOCK || block_info.payload_size < COMPRESSION_MIN_SIZE
-		    copy_block(block_info, from_io, to_io, buffer)
-		else
-		    # Get the data header
-		    data_header = from.data_header
-		    if data_header.compressed
-			copy_block(block_info, from_io, to_io, buffer)
-			next
-		    end
+            compressed = [1].pack('C')
+            buffer = "".encode('BINARY')
+            from.each_block(true) do |block_info|
+                if block_info.type != DATA_BLOCK || block_info.payload_size < COMPRESSION_MIN_SIZE
+                    copy_block(block_info, from_io, to_io, buffer)
+                else
+                    # Get the data header
+                    data_header = from.data_header
+                    if data_header.compressed
+                        copy_block(block_info, from_io, to_io, buffer)
+                        next
+                    end
 
-		    compressed = Zlib::Deflate.deflate(from.data)
-		    delta = data_header.size - compressed.size
-		    if Float(delta) / data_header.size > COMPRESSION_THRESHOLD
-			# Save it in compressed form
-			payload_size = DATA_HEADER_SIZE + compressed.size
-			to_io.write([block_info.type, block_info.index, payload_size].pack('CxvV'))
-			from_io.seek(block_info.pos + BLOCK_HEADER_SIZE)
-			from_io.read(TIME_SIZE * 2, buffer)
-			to_io.write(buffer << [compressed.size, 1].pack('VC'))
-			to_io.write(compressed)
-		    else
-			copy_block(block_info, from_io, to_io, buffer)
-		    end
-		end
-	    end
-	end
+                    compressed = Zlib::Deflate.deflate(from.data)
+                    delta = data_header.size - compressed.size
+                    if Float(delta) / data_header.size > COMPRESSION_THRESHOLD
+                        # Save it in compressed form
+                        payload_size = DATA_HEADER_SIZE + compressed.size
+                        to_io.write([block_info.type, block_info.index, payload_size].pack('CxvV'))
+                        from_io.seek(block_info.pos + BLOCK_HEADER_SIZE)
+                        from_io.read(TIME_SIZE * 2, buffer)
+                        to_io.write(buffer << [compressed.size, 1].pack('VC'))
+                        to_io.write(compressed)
+                    else
+                        copy_block(block_info, from_io, to_io, buffer)
+                    end
+                end
+            end
+        end
 
         def self.rename_streams(from_io, to_io, mappings)
             from = Logfiles.new(from_io)
             from.read_prologue
-	    write_prologue(to_io, from.endian_swap ^ Pocolog.big_endian?)
+            write_prologue(to_io, from.endian_swap ^ Pocolog.big_endian?)
 
             buffer = ""
-	    from.each_block(true) do |block_info|
-		if block_info.type == STREAM_BLOCK
-		    stream = from.read_stream_declaration
+            from.each_block(true) do |block_info|
+                if block_info.type == STREAM_BLOCK
+                    stream = from.read_stream_declaration
                     write_stream_declaration(to_io, stream.index,
                             mappings[stream.name] || stream.name,
                             stream.type, nil, stream.metadata)
                 else
-		    copy_block(block_info, from_io, to_io, buffer)
+                    copy_block(block_info, from_io, to_io, buffer)
                 end
             end
         end

--- a/lib/pocolog/data_reader.rb
+++ b/lib/pocolog/data_reader.rb
@@ -22,7 +22,7 @@ module Pocolog
         def initialize(logfile, index, name, type_name, marshalled_registry, metadata)
             @logfile, @index, @name, @type_name, @marshalled_registry, @metadata =
                 logfile, index, name, type_name, marshalled_registry, metadata
-	    
+            
             @data = nil
             @registry = nil
             @sample_index = -1
@@ -45,11 +45,11 @@ module Pocolog
             logfile.close
         end
 
-	# Returns a SampleEnumerator object for this stream
-	def samples(read_data = true); SampleEnumerator.new(self, read_data) end
+        # Returns a SampleEnumerator object for this stream
+        def samples(read_data = true); SampleEnumerator.new(self, read_data) end
 
-	# Enumerates the blocks of this stream
-	def each_block(rewind = true)
+        # Enumerates the blocks of this stream
+        def each_block(rewind = true)
             if rewind
                 self.rewind
             end
@@ -57,35 +57,35 @@ module Pocolog
             while advance
                 yield if block_given?
             end
-	end
+        end
 
-	# Returns the +sample_index+ sample of this stream
-	def [](sample_index)
-	    samples.between(sample_index, nil).
-		find { true }
-	end
+        # Returns the +sample_index+ sample of this stream
+        def [](sample_index)
+            samples.between(sample_index, nil).
+                find { true }
+        end
 
         attr_accessor :time_getter
 
         # Returns the time of the current sample
-	def time
+        def time
             header = logfile.data_header
             if !time_getter
                 [header.rt, Time.at(header.lg - logfile.time_base)]
             else
                 [header.rt, time_getter[data(header)]]
             end
-	end
+        end
 
-	# Get the logical time of first and last samples in this stream. If
-	# +rt+ is true, returns the interval for the wall-clock time
+        # Get the logical time of first and last samples in this stream. If
+        # +rt+ is true, returns the interval for the wall-clock time
         #
         # Returns nil if the stream is empty
-	def time_interval(rt = false)
-	    if rt then info.interval_rt
-	    else info.interval_lg
-	    end
-	end
+        def time_interval(rt = false)
+            if rt then info.interval_rt
+            else info.interval_lg
+            end
+        end
 
         # The data header for the current sample. You can store a copy of this
         # header to retrieve data later on with #data:
@@ -94,18 +94,18 @@ module Pocolog
         #   stored_header = stream.data_header.dup
         #   ...
         #   data = stream.data(stored_header)
-	def data_header; logfile.data_header end
+        def data_header; logfile.data_header end
 
-	# The size, in samples, of data in this stream
-	def size; info.size end
+        # The size, in samples, of data in this stream
+        def size; info.size end
 
         # True if we read past the last sample
         def eof?; size == sample_index end
         # True if the size of this stream is zero
         def empty?; size == 0 end
 
-	# True if this data stream has a Typelib::Registry object associated
-	def has_type?; !marshalled_registry.empty? end
+        # True if this data stream has a Typelib::Registry object associated
+        def has_type?; !marshalled_registry.empty? end
 
         # Reload the registry. Can be useful if new convertions have been added
         # to the Typelib system
@@ -115,14 +115,14 @@ module Pocolog
             registry
         end
 
-	# Get the Typelib::Registry object for this stream
-	def registry
-	    if !@registry
-		@registry = logfile.registry || Typelib::Registry.new
+        # Get the Typelib::Registry object for this stream
+        def registry
+            if !@registry
+                @registry = logfile.registry || Typelib::Registry.new
 
-		stream_registry = Typelib::Registry.new
+                stream_registry = Typelib::Registry.new
 
-		if has_type?
+                if has_type?
                     begin
                         stream_registry.merge_xml(marshalled_registry)
                     rescue ArgumentError
@@ -150,56 +150,56 @@ module Pocolog
                             raise e, e.message + ". Are you mixing 32 and 64 bit data ?", e.backtrace
                         end
                     end
-		end
-	    end
-	    @registry
-	end
+                end
+            end
+            @registry
+        end
 
-	# Get a Typelib object describing the type of this data stream
-	def type; @type ||= registry.get(typename) end
+        # Get a Typelib object describing the type of this data stream
+        def type; @type ||= registry.get(typename) end
 
-	#Returns the decoded subfield specified by 'fieldname'
-	#for the given data header. If no header is given, the
-	#current last read data header is used
-	def sub_field(fieldname, data_header = nil)
-	    header = data_header || logfile.data_header
-	    if( header.compressed )
-		data(data_header).send(fieldname)
-	    elsif(type.is_a?(Typelib::CompoundType) and type.has_field?(fieldname))
-		offset = type.offset_of(fieldname)
-		subtype = type[fieldname]
-		rawData = logfile.sub_field(offset, subtype.size, data_header)
-		wrappedType = subtype.wrap(rawData)
-		rubyType = Typelib.to_ruby(wrappedType)
-		rubyType
-	    else
-		nil
-	    end
-	end
-	    
-	# Returns the decoded data sample associated with the given block
+        #Returns the decoded subfield specified by 'fieldname'
+        #for the given data header. If no header is given, the
+        #current last read data header is used
+        def sub_field(fieldname, data_header = nil)
+            header = data_header || logfile.data_header
+            if( header.compressed )
+                data(data_header).send(fieldname)
+            elsif(type.is_a?(Typelib::CompoundType) and type.has_field?(fieldname))
+                offset = type.offset_of(fieldname)
+                subtype = type[fieldname]
+                rawData = logfile.sub_field(offset, subtype.size, data_header)
+                wrappedType = subtype.wrap(rawData)
+                rubyType = Typelib.to_ruby(wrappedType)
+                rubyType
+            else
+                nil
+            end
+        end
+            
+        # Returns the decoded data sample associated with the given block
         # header.
         #
         # Block headers are returned by #rewind 
-	def raw_data(data_header = nil, sample = nil)
-	    if(@data && !data_header) then @data
-	    else
+        def raw_data(data_header = nil, sample = nil)
+            if(@data && !data_header) then @data
+            else
                 marshalled_data = logfile.data(data_header, @raw_data_buffer)
-		data = sample || type.new
+                data = sample || type.new
                 data.from_buffer_direct(marshalled_data)
-		if logfile.endian_swap
-		    data = data.endian_swap
-		end
+                if logfile.endian_swap
+                    data = data.endian_swap
+                end
                 data
-	    end
+            end
         rescue Interrupt
             raise
         rescue Exception => e
             raise e, "failed to unmarshal sample at #{(data_header || logfile.data_header).payload_pos}: #{e.message}", e.backtrace
-	end
+        end
 
         def read_one_raw_data_sample(position, sample = nil)
-	    rio, block_pos = stream_index.file_position_by_sample_number(position)
+            rio, block_pos = stream_index.file_position_by_sample_number(position)
             marshalled_data = logfile.read_one_data_payload(rio, block_pos, @raw_data_buffer)
             data = sample || type.new
             data.from_buffer_direct(marshalled_data)
@@ -227,24 +227,24 @@ module Pocolog
         # Returns nil if the stream is empty.
         #
         # It differs from #first as it does not decode the data payload.
-	def rewind
+        def rewind
             # The first sample in the file has index 0, so set sample_index to
             # -1 so that (@sample_index += 1) sets the index to 0 for the first
             # sample
             @sample_index = -1
             nil
-	end
+        end
 
         # call-seq:
         #   first => [time_rt, time_lg, data]
         #
-	# Returns the first sample in the stream, or nil if the stream is empty
+        # Returns the first sample in the stream, or nil if the stream is empty
         #
         # It differs from #rewind as it always decodes the data payload.
         #
         # After a call to #first, #sample_index is 0
-	def first
-	    rewind
+        def first
+            rewind
             self.next
         end
 
@@ -271,59 +271,59 @@ module Pocolog
         #
         # Returns [rt, lg, data] for the current sample (if there is one), and
         # nil otherwise
-	def seek(pos, decode_data = true)
-	    if pos.kind_of?(Time)
+        def seek(pos, decode_data = true)
+            if pos.kind_of?(Time)
                 return nil if(time_interval.empty? || time_interval[0] > pos || time_interval[1] < pos)
-		@sample_index = stream_index.sample_number_by_time(pos)
-	    else
-		@sample_index = pos
-	    end
+                @sample_index = stream_index.sample_number_by_time(pos)
+            else
+                @sample_index = pos
+            end
 
-	    rio, file_pos = stream_index.file_position_by_sample_number(@sample_index)
-	    block_info = logfile.read_one_block(file_pos, rio)
+            rio, file_pos = stream_index.file_position_by_sample_number(@sample_index)
+            block_info = logfile.read_one_block(file_pos, rio)
             if block_info.index != self.index
                 raise InternalError, "index returned index=#{@sample_index} and pos=#{file_pos} as position for seek(#{pos}) but it seems to be a sample in stream #{logfile.stream_from_index(block_info.index).name} while we were expecting #{name}"
             end
             if header = self.data_header
                 header = header.dup
 
-		if(decode_data)
-		    data = self.data(header)
-		    return [header.rt, Time.at(header.lg - logfile.time_base), data]
-		else
-		    header
-		end
+                if(decode_data)
+                    data = self.data(header)
+                    return [header.rt, Time.at(header.lg - logfile.time_base), data]
+                else
+                    header
+                end
             end
-	end
+        end
 
         # Reads the next sample in the file, and returns its header. Returns nil
         # if the end of file has been reached. Unlike +next+, it does not
         # decodes the data payload.
-	def advance
+        def advance
             if sample_index < size-1
                 @sample_index += 1
-		rio, file_pos = stream_index.file_position_by_sample_number(@sample_index)
-		logfile.read_one_block(file_pos, rio)
-		return logfile.data_header
+                rio, file_pos = stream_index.file_position_by_sample_number(@sample_index)
+                logfile.read_one_block(file_pos, rio)
+                return logfile.data_header
             else
                 @sample_index = size
             end
-	    nil
-	end
+            nil
+        end
 
-	# call-seq:
+        # call-seq:
         #   next => [time_rt, time_lg, data]
         #
         # Reads the next sample in the file, and returns it. It differs from
         # +advance+ as it always decodes the data sample.
-	def next
-	    header = advance
+        def next
+            header = advance
             if(header) 
               return [header.rt, Time.at(header.lg - logfile.time_base), data]
             end
-	end
+        end
 
-	# call-seq:
+        # call-seq:
         #   previous => [time_rt, time_lg, data]
         #
         # Reads the previous sample in the file, and returns it.
@@ -340,7 +340,7 @@ module Pocolog
             end
         end
 
-	# call-seq:
+        # call-seq:
         #   copy_to(index1,index2,stream) => true 
         #   copy_to(time1,time2,stream) => true 
         #
@@ -397,7 +397,7 @@ module Pocolog
             counter
         end
 
-	# call-seq:
+        # call-seq:
         #   samples?(pos1,pos2) => true 
         #   samples?(time1,time2) => true 
         #
@@ -416,59 +416,59 @@ module Pocolog
     # Sample enumerators are nicer interfaces for data reading built on top of a DataStream
     # object
     class SampleEnumerator
-	include Enumerable
+        include Enumerable
 
-	attr_accessor :use_rt
-	attr_accessor :min_time,  :max_time,  :every_time
-	attr_accessor :min_index, :max_index, :every_index
-	attr_accessor :max_count
-	def setvar(name, val)
-	    time, index = case val
-			  when Integer then [nil, val]
-			  when Time then [val, nil] 
-			  end
+        attr_accessor :use_rt
+        attr_accessor :min_time,  :max_time,  :every_time
+        attr_accessor :min_index, :max_index, :every_index
+        attr_accessor :max_count
+        def setvar(name, val)
+            time, index = case val
+                          when Integer then [nil, val]
+                          when Time then [val, nil] 
+                          end
 
-	    send("#{name}_time=", time)
-	    send("#{name}_index=", index)
-	end
+            send("#{name}_time=", time)
+            send("#{name}_index=", index)
+        end
 
-	attr_reader :stream, :read_data
-	def initialize(stream, read_data)
-	    @stream = stream 
-	    @read_data = read_data
-	end
-	def every(interval)
-	    setvar('every', interval) 
-	    self
-	end
-	def from(from);
-	    setvar("min", from)
-	    self
-	end
-	def to(to)
-	    setvar("max", to)
-	    self
-	end
-	def between(from, to)
-	    self.from(from)
-	    self.to(to)
-	end
-	def at(pos)
-	    from(pos) 
-	    max(1)
-	end
+        attr_reader :stream, :read_data
+        def initialize(stream, read_data)
+            @stream = stream 
+            @read_data = read_data
+        end
+        def every(interval)
+            setvar('every', interval) 
+            self
+        end
+        def from(from);
+            setvar("min", from)
+            self
+        end
+        def to(to)
+            setvar("max", to)
+            self
+        end
+        def between(from, to)
+            self.from(from)
+            self.to(to)
+        end
+        def at(pos)
+            from(pos) 
+            max(1)
+        end
 
-	def realtime(use_rt = true)
-	    @use_rt = use_rt 
-	    self
-	end
-	def max(count)
-	    @max_count = count
-	    self
-	end
+        def realtime(use_rt = true)
+            @use_rt = use_rt 
+            self
+        end
+        def max(count)
+            @max_count = count
+            self
+        end
 
-	attr_accessor :next_sample
-	attr_accessor :sample_count
+        attr_accessor :next_sample
+        attr_accessor :sample_count
 
         def each(&block)
             raw_each do |rt, lg, raw_data|
@@ -476,11 +476,11 @@ module Pocolog
             end
         end
 
-	def raw_each(&block)
-	    self.sample_count = 0
-	    self.next_sample = nil
+        def raw_each(&block)
+            self.sample_count = 0
+            self.next_sample = nil
 
-	    last_data_block = nil
+            last_data_block = nil
 
             min_index = self.min_index
             min_time  = self.min_time
@@ -492,58 +492,58 @@ module Pocolog
                     stream.seek(min_index || min_time)
                 end
             end
-	    stream.each_block(!(min_index || min_time)) do
+            stream.each_block(!(min_index || min_time)) do
                 sample_index = stream.sample_index
-		return self if max_index && max_index < sample_index
-		return self if max_count && max_count <= sample_count
+                return self if max_index && max_index < sample_index
+                return self if max_count && max_count <= sample_count
 
-		rt, lg = stream.time
-		sample_time = if use_rt then rt
-			      else lg
-			      end
+                rt, lg = stream.time
+                sample_time = if use_rt then rt
+                              else lg
+                              end
 
-		if min_time
-		    if sample_time < min_time
-			last_data_block = stream.data_header.dup
-			next
-		    elsif last_data_block
-			last_data_time = if use_rt then last_data_block.rt
-					 else last_data_block.lg
-					 end
-			yield_sample(last_data_time, sample_index - 1, last_data_block, &block)
-			last_data_block = nil
-		    end
-		end
-		return self if max_time && max_time < sample_time
+                if min_time
+                    if sample_time < min_time
+                        last_data_block = stream.data_header.dup
+                        next
+                    elsif last_data_block
+                        last_data_time = if use_rt then last_data_block.rt
+                                         else last_data_block.lg
+                                         end
+                        yield_sample(last_data_time, sample_index - 1, last_data_block, &block)
+                        last_data_block = nil
+                    end
+                end
+                return self if max_time && max_time < sample_time
 
-		yield_sample(sample_time, sample_index, stream.data_header, &block)
-	    end
-	    self
-	end
+                yield_sample(sample_time, sample_index, stream.data_header, &block)
+            end
+            self
+        end
 
-	# Yield the given sample if required by our configuration
-	def yield_sample(sample_time, sample_index, data_block = nil)
-	    do_display = !next_sample
-	    if every_time 
-		self.next_sample ||= sample_time
-		while self.next_sample <= sample_time
-		    do_display = true
-		    self.next_sample += every_time.to_f
-		end
-	    elsif every_index
-		self.next_sample ||= sample_index
-		if self.next_sample <= sample_index
-		    do_display = true
-		    self.next_sample += every_index
-		end
-	    end
+        # Yield the given sample if required by our configuration
+        def yield_sample(sample_time, sample_index, data_block = nil)
+            do_display = !next_sample
+            if every_time 
+                self.next_sample ||= sample_time
+                while self.next_sample <= sample_time
+                    do_display = true
+                    self.next_sample += every_time.to_f
+                end
+            elsif every_index
+                self.next_sample ||= sample_index
+                if self.next_sample <= sample_index
+                    do_display = true
+                    self.next_sample += every_index
+                end
+            end
 
-	    if do_display
-		self.sample_count += 1
-		yield(data_block.rt, data_block.lg, (stream.raw_data(data_block) if read_data))
-		last_data_block = nil
-	    end
-	end
+            if do_display
+                self.sample_count += 1
+                yield(data_block.rt, data_block.lg, (stream.raw_data(data_block) if read_data))
+                last_data_block = nil
+            end
+        end
     end
 end
 

--- a/lib/pocolog/data_writer.rb
+++ b/lib/pocolog/data_writer.rb
@@ -1,18 +1,18 @@
 module Pocolog
     class DataStream
-	# Write a sample in this stream, with the +rt+ and +lg+
-	# timestamps. +data+ can be either a Typelib::Type object of the
-	# right type, or a String (in which case we consider that it is
-	# the raw data)
-	def write(rt, lg, data)
+        # Write a sample in this stream, with the +rt+ and +lg+
+        # timestamps. +data+ can be either a Typelib::Type object of the
+        # right type, or a String (in which case we consider that it is
+        # the raw data)
+        def write(rt, lg, data)
             data = Typelib.from_ruby(data, type)
             write_raw(rt, lg, data.to_byte_array)
-	end
+        end
 
         # Write an already marshalled sample. +data+ is supposed to be a
         # typelib-marshalled value of the stream type
         def write_raw(rt, lg, data)
-	    logfile.write_data_block(self, rt, lg, data)
+            logfile.write_data_block(self, rt, lg, data)
         end
     end
 end

--- a/lib/pocolog/file.rb
+++ b/lib/pocolog/file.rb
@@ -39,38 +39,38 @@ module Pocolog
     class Logfiles
         # Format version ID. Increment this when the file format changes in a
         # non-backward-compatible way
-	FORMAT_VERSION = 2
+        FORMAT_VERSION = 2
 
         # The size of the generic block header
-	BLOCK_HEADER_SIZE = 8
+        BLOCK_HEADER_SIZE = 8
         # The size of a time in a block header
-	TIME_SIZE = 8
+        TIME_SIZE = 8
         # The size of a data header, excluding the generic block header
-	DATA_HEADER_SIZE = TIME_SIZE * 2 + 5
+        DATA_HEADER_SIZE = TIME_SIZE * 2 + 5
 
-	# Data blocks of less than COMPRESSION_MIN_SIZE are never compressed
-	COMPRESSION_MIN_SIZE = 60 * 1024
-	# If the size gained by compressing is below this value, do not save in
-	# compressed form
-	COMPRESSION_THRESHOLD = 0.3
+        # Data blocks of less than COMPRESSION_MIN_SIZE are never compressed
+        COMPRESSION_MIN_SIZE = 60 * 1024
+        # If the size gained by compressing is below this value, do not save in
+        # compressed form
+        COMPRESSION_THRESHOLD = 0.3
 
         # Exception thrown when opening if the log file is not 
         #
         # One should run pocolog --upgrade-version when this happen
-	class ObsoleteVersion < RuntimeError; end
+        class ObsoleteVersion < RuntimeError; end
         # Logfiles.open could not find a valid prologue in the provided file(s)
         #
         # This is most often because the provided file(s) are not pocolog files
-	class MissingPrologue < RuntimeError; end
+        class MissingPrologue < RuntimeError; end
 
         # Structure that stores additional information about a block
-	BlockInfo = Struct.new :io, :pos, :type, :index, :payload_size
+        BlockInfo = Struct.new :io, :pos, :type, :index, :payload_size
         # The BlockInfo instance storing information about the last block read
-	attr_reader :block_info
+        attr_reader :block_info
 
-	# Whether or not data bigger than COMPRESSION_MIN_SIZE should be
-	# compressed using Zlib when written to this log file. Defaults to true
-	attr_predicate :compress?, true
+        # Whether or not data bigger than COMPRESSION_MIN_SIZE should be
+        # compressed using Zlib when written to this log file. Defaults to true
+        attr_predicate :compress?, true
 
         # Returns true if +file+ is a valid, up-to-date, pocolog file
         def self.valid_file?(file)
@@ -81,9 +81,9 @@ module Pocolog
         end
 
         # An array of IO objects representing the underlying files
-	attr_reader :io
+        attr_reader :io
         # The type registry for these logfiles, as a Typelib::Registry instance
-	attr_reader :registry
+        attr_reader :registry
 
         # call-seq:
         #   Logfiles.open(io1, io2)
@@ -99,18 +99,18 @@ module Pocolog
         # Providing a type registry guarantees that you get an error if the
         # logfile's types do not match the type definitions found in the
         # registry.
-	def initialize(*io)
-	    if io.last.kind_of?(Typelib::Registry)
-		@registry = io.pop
-	    end
+        def initialize(*io)
+            if io.last.kind_of?(Typelib::Registry)
+                @registry = io.pop
+            end
 
-	    @io          = io
+            @io          = io
             @io_size     = io.map { |rio| rio.stat.size }
-	    @streams     = nil
-	    @block_info  = BlockInfo.new
-	    @compress    = true
+            @streams     = nil
+            @block_info  = BlockInfo.new
+            @compress    = true
             @data_header_buffer = ""
-	    rewind
+            rewind
             if io.empty?
                 # When opening existing files, @streams is going to be
                 # initialized in #streams. However, if we are creating a new set
@@ -120,19 +120,19 @@ module Pocolog
             else
                 read_prologue
             end
-	end
+        end
 
         def closed?
             @io.all? { |io| io.closed? }
         end
 
         # Close the underlying IO objects
-	def close
-	    io.each { |file| file.close }
-	end
+        def close
+            io.each { |file| file.close }
+        end
 
         def open
-	    @io = io.map do |file|
+            @io = io.map do |file|
                 if file.closed?
                     File.open(file.path)
                 else file
@@ -140,16 +140,16 @@ module Pocolog
             end
         end
 
-	# The basename for creating new log files. The files
-	# names are
-	#
-	#   #{basename}.#{index}.log
-	attr_accessor :basename
+        # The basename for creating new log files. The files
+        # names are
+        #
+        #   #{basename}.#{index}.log
+        attr_accessor :basename
 
         # Returns the current position in the current IO
         #
         # This is the position of the next block.
-	def tell; @next_block_pos end
+        def tell; @next_block_pos end
 
         # call-seq:
         #   seek(data_header) => position
@@ -159,7 +159,7 @@ module Pocolog
         # the place where the data_header is stored. In the second form, seeks
         # to the given raw position, and optionally changes the current IO
         # object (rio is an index in the set of IOs given to #initialize)
-	def seek(pos, rio = nil)
+        def seek(pos, rio = nil)
             if pos.kind_of?(DataHeader)
                 unless io_index = @io.index(pos.io)
                     raise "#{pos} does not come from this log fileset"
@@ -167,24 +167,24 @@ module Pocolog
                 @rio = io_index
                 @next_block_pos = pos.block_pos
             else
-		raise ArgumentError, "need rio argument, if pos is not a DataHeader" unless rio
-		@rio = rio
+                raise ArgumentError, "need rio argument, if pos is not a DataHeader" unless rio
+                @rio = rio
                 @next_block_pos = pos
             end
             nil
         end
 
-	# Continue writing logs in a new file. See #basename to know how
-	# files are named
-	def new_file(filename = nil)
-	    name = filename || "#{basename}.#{@io.size}.log"
-	    io = File.new(name, 'w')
-	    Logfiles.write_prologue(io)
-	    @io << io
-	    streams.each_with_index do |s, i|
-		write_stream_declaration(i, s.name, s.type.name, registry.to_xml)
-	    end
-	end
+        # Continue writing logs in a new file. See #basename to know how
+        # files are named
+        def new_file(filename = nil)
+            name = filename || "#{basename}.#{@io.size}.log"
+            io = File.new(name, 'w')
+            Logfiles.write_prologue(io)
+            @io << io
+            streams.each_with_index do |s, i|
+                write_stream_declaration(i, s.name, s.type.name, registry.to_xml)
+            end
+        end
 
         # Opens a set of file. +pattern+ can be a globbing pattern, in which
         # case all the matching files will be opened as a log sequence
@@ -200,111 +200,111 @@ module Pocolog
             new(*io)
         end
 
-	# Create an empty log file using +basename+ to build its name.
+        # Create an empty log file using +basename+ to build its name.
         # Namely, it will create a new file named <basename>.0.log. Then,
         # calls to #new_file would create <basename>.1.log and so on
-	def self.create(basename, registry = nil)
+        def self.create(basename, registry = nil)
             if !registry
                 registry = Typelib::Registry.new
                 Typelib::Registry.add_standard_cxx_types(registry)
             end
-	    file = Logfiles.new(registry)
-	    file.basename = basename
-	    file.new_file
+            file = Logfiles.new(registry)
+            file.basename = basename
+            file.new_file
 
-	    file
-	end
+            file
+        end
 
-	# Open an already existing set of log files or create it
-	def self.append(basename)
-	    io = []
-	    i = 0
-	    while File.readable?(path = "#{basename}.#{i}.log")
-		io << File.open(path, 'a+')
-		i += 1
-	    end
+        # Open an already existing set of log files or create it
+        def self.append(basename)
+            io = []
+            i = 0
+            while File.readable?(path = "#{basename}.#{i}.log")
+                io << File.open(path, 'a+')
+                i += 1
+            end
 
-	    if io.empty?
-		return create(basename)
-	    end
+            if io.empty?
+                return create(basename)
+            end
 
-	    file = Logfiles.new(*io)
-	    file.basename = basename
-	    file
-	end
+            file = Logfiles.new(*io)
+            file.basename = basename
+            file
+        end
 
-	def initialize_copy(from) # :nodoc:
-	    super
+        def initialize_copy(from) # :nodoc:
+            super
 
-	    @io		 = from.io.map { |obj| obj.dup }
-	    @registry    = from.registry
-	    @block_info  = BlockInfo.new
-	    @time_base   = @time_base.dup
-	    @time_offset = @time_offset.dup
-	end
+            @io          = from.io.map { |obj| obj.dup }
+            @registry    = from.registry
+            @block_info  = BlockInfo.new
+            @time_base   = @time_base.dup
+            @time_offset = @time_offset.dup
+        end
 
-	# Returns at the beginning of the first file of the file set
-	def rewind
-	    @rio     = 0
-	    @time_base      = []
-	    @time_offset    = []
-	    @next_block_pos = 0
+        # Returns at the beginning of the first file of the file set
+        def rewind
+            @rio     = 0
+            @time_base      = []
+            @time_offset    = []
+            @next_block_pos = 0
 
-	    @data_header = DataHeader.new
-	    @data = nil
-	end
+            @data_header = DataHeader.new
+            @data = nil
+        end
 
-	attr_reader :format_version # :nodoc:
-	MAGIC = "POCOSIM" # :nodoc:
-	    
+        attr_reader :format_version # :nodoc:
+        MAGIC = "POCOSIM" # :nodoc:
+            
         # Tries to read the prologue of the underlying files
         #
         # Raises MissingPrologue if no prologue is found, or ObsoleteVersion if
         # the file format is not up-to-date (in which case one has to run
         # pocolog --to-new-format).
-	def read_prologue # :nodoc:
-	    io = rio
-	    io.seek(0)
-	    magic	   = io.read(MAGIC.size)
-	    if magic != MAGIC
+        def read_prologue # :nodoc:
+            io = rio
+            io.seek(0)
+            magic          = io.read(MAGIC.size)
+            if magic != MAGIC
                 if !magic
                     raise MissingPrologue, "#{io.path} is empty"
                 else
                     raise MissingPrologue, "#{io.path} is not a pocolog log file"
                 end
-	    end
+            end
 
-	    @format_version, big_endian = io.read(9).unpack('xVV')
-	    @endian_swap = ((big_endian != 0) ^ Pocolog.big_endian?)
-	    if format_version < FORMAT_VERSION
-		raise ObsoleteVersion, "old format #{format_version}, current format is #{FORMAT_VERSION}. Convert it using the --to-new-format of pocolog"
-	    elsif format_version > FORMAT_VERSION
-		raise "this file is in v#{format_version} which is newer that the one we know #{FORMAT_VERSION}. Update pocolog"
-	    end
-	    @next_block_pos = rio.tell
-	end
+            @format_version, big_endian = io.read(9).unpack('xVV')
+            @endian_swap = ((big_endian != 0) ^ Pocolog.big_endian?)
+            if format_version < FORMAT_VERSION
+                raise ObsoleteVersion, "old format #{format_version}, current format is #{FORMAT_VERSION}. Convert it using the --to-new-format of pocolog"
+            elsif format_version > FORMAT_VERSION
+                raise "this file is in v#{format_version} which is newer that the one we know #{FORMAT_VERSION}. Update pocolog"
+            end
+            @next_block_pos = rio.tell
+        end
 
-	# Continue reading on the next IO object, or raise EOFError if we
-	# are currently reading the last one
-	def next_io
-	    @rio += 1
-	    if @io.size == @rio
-		raise EOFError
-	    else
-		read_prologue
-		rio
-	    end
-	end
+        # Continue reading on the next IO object, or raise EOFError if we
+        # are currently reading the last one
+        def next_io
+            @rio += 1
+            if @io.size == @rio
+                raise EOFError
+            else
+                read_prologue
+                rio
+            end
+        end
 
         # True if we read the last block in the file set
         def eof?; @io.size == @rio end
-	# Returns the IO object currently used for reading
-	def rio; @io[@rio] end
-	# Returns the IO object currently used for writing
-	def wio; @io.last end
+        # Returns the IO object currently used for reading
+        def rio; @io[@rio] end
+        # Returns the IO object currently used for writing
+        def wio; @io.last end
         # Returns the file size of the IO object currently used
         def file_size; @io_size[@rio] end
-	
+        
         # Yields a BlockInfo instance for each block found in the file set.
         #
         # If +rewind+ is true, rewind the file to the first block before
@@ -314,28 +314,28 @@ module Pocolog
         # after rewind. It is meant to be used internally to upgrade old files.
         #
         # This is not meant for direct use. Use #each_data_block instead.
-	def each_block(rewind = true, with_prologue = true)
-	    self.rewind if rewind
-	    while !eof?
-		io = self.rio
-		if @next_block_pos == 0 && with_prologue
-		    read_prologue
-		else
-		    io.seek(@next_block_pos)
-		end
+        def each_block(rewind = true, with_prologue = true)
+            self.rewind if rewind
+            while !eof?
+                io = self.rio
+                if @next_block_pos == 0 && with_prologue
+                    read_prologue
+                else
+                    io.seek(@next_block_pos)
+                end
 
-		@data = nil
-		@data_header.updated = false
+                @data = nil
+                @data_header.updated = false
 
                 if !read_block_header
                     next_io
                     next
                 end
 
-		yield(@block_info)
-	    end
-	rescue EOFError
-	end
+                yield(@block_info)
+            end
+        rescue EOFError
+        end
 
         # Reads one block at the specified position and returns the block type
         # (equal to block_info.type). If the block is a control or stream block,
@@ -357,12 +357,12 @@ module Pocolog
         # Reads the next data sample in the file, and returns its header.
         # Returns nil if the end of file has been reached. Unlike +next+, it
         # does not decodes the data payload.
-	def advance(index)
+        def advance(index)
             each_data_block(index, false) do
                 return data_header
             end
             nil
-	end
+        end
 
         # Gets the block information in +block_info+ and acts accordingly: calls
         # the relevant parsing methods if it is a control or stream block. It
@@ -420,12 +420,12 @@ module Pocolog
             true
         end
 
-	# call-seq:
+        # call-seq:
         #   each_data_block([stream_index[, rewind]]) do |stream_index|
         #   end
         #
         # Yields for each data block in stream +stream_index+, or in all
-	# streams if +stream_index+ is nil. The block header can be retrieved
+        # streams if +stream_index+ is nil. The block header can be retrieved
         # using #data_header, and the sample by using #data
         #
         # If +rewind+ is true, starts at the beginning of the file. Otherwise,
@@ -433,30 +433,30 @@ module Pocolog
         #
         # The with_prologue parameter is a backward compatibility feature that
         # allowed to read old files that did not have a prologue.
- 	def each_data_block(stream_index = nil, rewind = true, with_prologue = true)
-	    each_block(rewind) do |block_info|
+        def each_data_block(stream_index = nil, rewind = true, with_prologue = true)
+            each_block(rewind) do |block_info|
                 if handle_block(block_info) == DATA_BLOCK
                     if !stream_index || stream_index == block_info.index
                         yield(block_info.index)
                     end
                 end
-	    end
+            end
 
-	rescue EOFError
-	rescue
-	    if !rio
-		raise $!
+        rescue EOFError
+        rescue
+            if !rio
+                raise $!
             elsif !rio.closed?
-		raise $!, "#{$!.message} at position #{rio.pos}", $!.backtrace
-	    end
-	end
+                raise $!, "#{$!.message} at position #{rio.pos}", $!.backtrace
+            end
+        end
 
         # Basic information about a stream, as saved in the index files
         class StreamInfo
-	    STREAM_INFO_VERSION = "1.2"
-	    
-	    #the version of the StreamInfo class. This is only used to detect
-	    #if an old index file is on the disk compared to the code 
+            STREAM_INFO_VERSION = "1.2"
+            
+            #the version of the StreamInfo class. This is only used to detect
+            #if an old index file is on the disk compared to the code 
             attr_accessor :version
             # Position of the declaration block as [raw_pos, io_index]. This
             # information can directly be given to Logfiles#seek
@@ -474,15 +474,15 @@ module Pocolog
             # The number of samples in this stream
             attr_accessor :size
 
-	    # The index data itself. 
-	    # This is a instance of StreamIndex
+            # The index data itself. 
+            # This is a instance of StreamIndex
             attr_accessor :index
 
             # True if this stream is empty
             def empty?; size == 0 end
 
             def initialize
-		@version = STREAM_INFO_VERSION
+                @version = STREAM_INFO_VERSION
                 @interval_io = []
                 @interval_lg = []
                 @interval_rt = []
@@ -519,9 +519,9 @@ module Pocolog
             end
 
             stream_info.each_with_index do |info, idx|
-		if(!info.respond_to?("version") || info.version != StreamInfo::STREAM_INFO_VERSION || !info.declaration_block)
-		    raise InvalidIndex, "old index file found"
-		end
+                if(!info.respond_to?("version") || info.version != StreamInfo::STREAM_INFO_VERSION || !info.declaration_block)
+                    raise InvalidIndex, "old index file found"
+                end
 
                 @rio, pos = info.declaration_block
                 if read_one_block(pos, @rio).type != STREAM_BLOCK
@@ -540,9 +540,9 @@ module Pocolog
                         raise InvalidIndex, "invalid interval_io: stream index mismatch for #{@streams[idx].name}. Expected #{idx}, got #{data_block_index}."
                     end
 
-		    if !info.index.sane?
+                    if !info.index.sane?
                         raise InvalidIndex, "index failed internal sanity check"
-		    end
+                    end
 
                     @streams[idx].instance_variable_set(:@info, info)
                 end
@@ -551,7 +551,7 @@ module Pocolog
 
         rescue InvalidIndex => e
             Pocolog.warn "invalid index file #{index_filename}: #{e.message}"
-	    nil
+            nil
         end
 
         # Returns a stream from its index
@@ -559,20 +559,20 @@ module Pocolog
             @streams[index]
         end
 
-	# Loads and returns the set of data streams found in this file. Will
+        # Loads and returns the set of data streams found in this file. Will
         # lazily build an index file when required.
-	def streams
-	    return @streams.compact if @streams
+        def streams
+            return @streams.compact if @streams
 
             index_filename = File.basename(@io[0].path, File.extname(@io[0].path)) + ".idx"
             index_filename = File.join(File.dirname(@io[0].path), index_filename)
             if streams = load_index_file(index_filename)
                 return streams
             end
-	    
+            
             # No index file. Compute it.
             Pocolog.info "building index #{index_filename} ..."
-	    each_data_block(nil, true) do |stream_index|
+            each_data_block(nil, true) do |stream_index|
                 # The stream object itself is built when the declaration block
                 # has been found
                 s    = @streams[stream_index]
@@ -581,34 +581,34 @@ module Pocolog
                 else
                     info = s.info
                     info.interval_io[1] = [@rio, block_info.pos]
-		    info.interval_io[0] ||= info.interval_io[1]
+                    info.interval_io[0] ||= info.interval_io[1]
 
-		    info.index.add_sample_to_index(@rio, data_header.block_pos, data_header.lg)		    
+                    info.index.add_sample_to_index(@rio, data_header.block_pos, data_header.lg)             
                     info.size += 1
                 end
-	    end
+            end
 
             if !@streams
                 Pocolog.info "done"
                 return []
             end
 
-	    @streams.each do |s|
-		next unless s
+            @streams.each do |s|
+                next unless s
 
-		#set correct time interval
+                #set correct time interval
                 stream_info = s.info
-		if !stream_info.empty?
-		    @rio, pos = stream_info.interval_io[0]
-		    rio.seek(pos + BLOCK_HEADER_SIZE)
+                if !stream_info.empty?
+                    @rio, pos = stream_info.interval_io[0]
+                    rio.seek(pos + BLOCK_HEADER_SIZE)
                     stream_info.interval_rt[0] = read_time
                     stream_info.interval_lg[0] = read_time
-		    @rio, pos = stream_info.interval_io[1] || stream_info.interval_io[0]
-		    rio.seek(pos + BLOCK_HEADER_SIZE)
+                    @rio, pos = stream_info.interval_io[1] || stream_info.interval_io[0]
+                    rio.seek(pos + BLOCK_HEADER_SIZE)
                     stream_info.interval_rt[1] = read_time
-                    stream_info.interval_lg[1] = read_time	    
-		end
-	    end
+                    stream_info.interval_lg[1] = read_time          
+                end
+            end
 
             file_info   = @io.map { |io| [File.size(io.path), io.mtime] }
             stream_info = @streams.compact.map { |s| s.info }
@@ -622,184 +622,184 @@ module Pocolog
                 raise
             end
             Pocolog.info "done"
-	    @streams.compact
-	end
+            @streams.compact
+        end
 
-	# True if there is a stream +index+
-	def declared_stream?(index)
-	    @streams && (@streams.size > index && @streams[index]) 
-	end
+        # True if there is a stream +index+
+        def declared_stream?(index)
+            @streams && (@streams.size > index && @streams[index]) 
+        end
 
-	# Returns the Time object which describes the 'zero' of this data
-	# set
-	def time_base
-	    if @time_base.empty?
-		Time.at(0)
-	    else
-		@time_base.last[1] 
-	    end
-	end
+        # Returns the Time object which describes the 'zero' of this data
+        # set
+        def time_base
+            if @time_base.empty?
+                Time.at(0)
+            else
+                @time_base.last[1] 
+            end
+        end
 
-	# Returns the offset from #time_base
-	def time_offset
-	    if @time_offset.empty? then 0
-	    else @time_offset.last[1] 
-	    end
-	end
+        # Returns the offset from #time_base
+        def time_offset
+            if @time_offset.empty? then 0
+            else @time_offset.last[1] 
+            end
+        end
 
-	# Reads a control block, which is used to set either #time_base
-	# or #time_offset
-	def read_control_block # :nodoc:
-	    control_time  = read_time
-	    control_block_type = rio.read(1).unpack('C').first
-	    control_value = read_time
-	    if control_block_type == CONTROL_SET_TIMEBASE
-		@time_base << [control_time, control_value]
-	    elsif control_block_type == CONTROL_SET_TIMEOFFSET
-		@time_offset << [control_time, Float(control_value.tv_sec) + control_value.tv_usec / 1.0e6]
-	    else 
-		raise "unknown control block type #{control_block_type}"
-	    end
-	end
+        # Reads a control block, which is used to set either #time_base
+        # or #time_offset
+        def read_control_block # :nodoc:
+            control_time  = read_time
+            control_block_type = rio.read(1).unpack('C').first
+            control_value = read_time
+            if control_block_type == CONTROL_SET_TIMEBASE
+                @time_base << [control_time, control_value]
+            elsif control_block_type == CONTROL_SET_TIMEOFFSET
+                @time_offset << [control_time, Float(control_value.tv_sec) + control_value.tv_usec / 1.0e6]
+            else 
+                raise "unknown control block type #{control_block_type}"
+            end
+        end
 
         # Reads the stream declaration block present at the current position in
         # the file.
         #
         # Raise if a new definition block is found for an already existing
         # stream, and the definition does not match the old one.
-	def read_stream_declaration # :nodoc:
-	    if block_info.payload_size <= 8
-		raise "bad data size #{block_info.size}"
-	    end
+        def read_stream_declaration # :nodoc:
+            if block_info.payload_size <= 8
+                raise "bad data size #{block_info.size}"
+            end
 
             io_index      = @rio
-	    block_start   = rio.tell
-	    _type         = rio.read(1)
-	    name_size     = rio.read(4).unpack('V').first
-	    name          = rio.read(name_size)
-	    typename_size = rio.read(4).unpack('V').first
-	    typename      = rio.read(typename_size)
+            block_start   = rio.tell
+            _type         = rio.read(1)
+            name_size     = rio.read(4).unpack('V').first
+            name          = rio.read(name_size)
+            typename_size = rio.read(4).unpack('V').first
+            typename      = rio.read(typename_size)
 
             # Load the registry if it seems that there is one
-	    unless rio.tell == block_start + block_info.payload_size
-		registry_size = rio.read(4).unpack('V').first
-		registry      = rio.read(registry_size)
-	    end
+            unless rio.tell == block_start + block_info.payload_size
+                registry_size = rio.read(4).unpack('V').first
+                registry      = rio.read(registry_size)
+            end
 
             # Load the metadata if it seems that there is one
-	    unless rio.tell == block_start + block_info.payload_size
-		metadata_size = rio.read(4).unpack('V').first
-		metadata      = rio.read(metadata_size)
-	    end
+            unless rio.tell == block_start + block_info.payload_size
+                metadata_size = rio.read(4).unpack('V').first
+                metadata      = rio.read(metadata_size)
+            end
 
-	    stream_index = block_info.index
-	    if @streams && (old = @streams[stream_index])
-		unless old.name == name && old.typename == typename || old.registry == registry
-		    raise "stream #{name} changed definition"
-		end
-		old
-	    else
-		@streams ||= Array.new
-		s = (@streams[stream_index] = DataStream.new(self.dup, stream_index, name, typename, registry || '', YAML.load(metadata || '') || Hash.new))
+            stream_index = block_info.index
+            if @streams && (old = @streams[stream_index])
+                unless old.name == name && old.typename == typename || old.registry == registry
+                    raise "stream #{name} changed definition"
+                end
+                old
+            else
+                @streams ||= Array.new
+                s = (@streams[stream_index] = DataStream.new(self.dup, stream_index, name, typename, registry || '', YAML.load(metadata || '') || Hash.new))
 
                 info = StreamInfo.new
                 s.instance_variable_set(:@info, info)
                 info.declaration_block = [io_index, block_info.pos]
                 s.rewind
                 s
-	    end
-	end
+            end
+        end
 
-	# True if the host byte order is not the same than the file byte
-	# order
-	attr_reader :endian_swap
+        # True if the host byte order is not the same than the file byte
+        # order
+        attr_reader :endian_swap
 
         # Reads a time at the current position, and returns it as a Time object
-	def read_time # :nodoc:
-	    rt_sec, rt_usec = rio.read(TIME_SIZE).unpack('VV')
-	    Time.at(rt_sec, rt_usec)
-	end
+        def read_time # :nodoc:
+            rt_sec, rt_usec = rio.read(TIME_SIZE).unpack('VV')
+            Time.at(rt_sec, rt_usec)
+        end
 
-	DataHeader = Struct.new :io, :block_pos, :payload_pos, :rt, :lg, :size, :compressed, :updated
+        DataHeader = Struct.new :io, :block_pos, :payload_pos, :rt, :lg, :size, :compressed, :updated
 
-	# Reads the header of a data block. This sets the @data_header
-	# instance variable to a new DataHeader object describing the
-	# last read block. If you want to keep a reference on a data block,
-	# and read it later, do the following
-	#
-	#   block = file.data_header.dup
-	#   [do something, including reading the file]
-	#   data  = file.data(block)
-	def data_header
-	    if @data_header.updated
-		@data_header
-	    else
-		data_block_pos = rio.tell
+        # Reads the header of a data block. This sets the @data_header
+        # instance variable to a new DataHeader object describing the
+        # last read block. If you want to keep a reference on a data block,
+        # and read it later, do the following
+        #
+        #   block = file.data_header.dup
+        #   [do something, including reading the file]
+        #   data  = file.data(block)
+        def data_header
+            if @data_header.updated
+                @data_header
+            else
+                data_block_pos = rio.tell
                 expected_header_size = TIME_SIZE * 2 + 5
                 result = rio.read(expected_header_size)
                 if result.size != expected_header_size
                     raise NotEnoughData, "expected to have #{expected_header_size} bytes remaining, but got only #{@data_header_buffer.size}, you may want to try running pocolog-repair on this file"
                 end
 
-		rt_sec, rt_usec, lg_sec, lg_usec, data_size, compressed =
+                rt_sec, rt_usec, lg_sec, lg_usec, data_size, compressed =
                     result.unpack('VVVVVC')
                 rt = Time.at(rt_sec, rt_usec)
                 lg = Time.at(lg_sec, lg_usec)
                 payload_pos = data_block_pos + TIME_SIZE * 2 + 5
 
-		size = payload_pos + data_size - data_block_pos
-		expected = block_info.payload_size
-		if size != expected
+                size = payload_pos + data_size - data_block_pos
+                expected = block_info.payload_size
+                if size != expected
                     if rio.respond_to?(:path)
                         file = " in #{rio.path}"
                     end
-		    raise NotEnoughData, "payload#{file} at position #{data_block_pos} was expected to be #{expected} bytes, but found #{size}, you may want to try running pocolog-repair on this file"
-		end
+                    raise NotEnoughData, "payload#{file} at position #{data_block_pos} was expected to be #{expected} bytes, but found #{size}, you may want to try running pocolog-repair on this file"
+                end
 
-		@data_header.io  = rio
+                @data_header.io  = rio
                 @data_header.block_pos   = @block_info.pos
-		@data_header.payload_pos = payload_pos
-		@data_header.rt = rt
-		@data_header.lg = lg
-		@data_header.size = data_size
-		@data_header.compressed = (compressed != 0)
-		@data_header.updated = true
-		@data_header
-	    end
-	end
+                @data_header.payload_pos = payload_pos
+                @data_header.rt = rt
+                @data_header.lg = lg
+                @data_header.size = data_size
+                @data_header.compressed = (compressed != 0)
+                @data_header.updated = true
+                @data_header
+            end
+        end
 
-	def sub_field(offset, size, data_header = nil)
-	    data_header ||= self.data_header
-	    if data_header.compressed
-		raise "field access on compressed files is unsupported"
-	    end
-	    data_header.io.seek(data_header.payload_pos + offset)
-	    data = data_header.io.read(size)
-	    data
-	end
+        def sub_field(offset, size, data_header = nil)
+            data_header ||= self.data_header
+            if data_header.compressed
+                raise "field access on compressed files is unsupported"
+            end
+            data_header.io.seek(data_header.payload_pos + offset)
+            data = data_header.io.read(size)
+            data
+        end
 
         def validate_data_block
             data_header = self.data_header
             data_header.io.seek(data_header.payload_pos + data_header.size)
         end
-	
-	# Returns the raw data payload of the current block
-	def data(data_header = nil, buffer = nil)
-	    if @data && !data_header then @data
-	    else
-		data_header ||= self.data_header
-		data_header.io.seek(data_header.payload_pos)
-		data = data_header.io.read(data_header.size, buffer)
-		if data_header.compressed
-		    # Payload is compressed
-		    data = Zlib::Inflate.inflate(data)
-		end
+        
+        # Returns the raw data payload of the current block
+        def data(data_header = nil, buffer = nil)
+            if @data && !data_header then @data
+            else
+                data_header ||= self.data_header
+                data_header.io.seek(data_header.payload_pos)
+                data = data_header.io.read(data_header.size, buffer)
+                if data_header.compressed
+                    # Payload is compressed
+                    data = Zlib::Inflate.inflate(data)
+                end
                 if !data_header
                     @data = data
                 end
                 data
-	    end
-	end
+            end
+        end
 
         def read_one_data_payload(rio, position, buffer = nil)
             io = @io[rio]
@@ -815,8 +815,8 @@ module Pocolog
 
         # Formats a block and writes it to +io+
         def self.write_block(wio, type, index, payload)
-	    wio << [type, index, payload.size].pack('CxvV')
-	    wio << payload
+            wio << [type, index, payload.size].pack('CxvV')
+            wio << payload
             return wio
         end
 
@@ -850,25 +850,25 @@ module Pocolog
                 type_registry.size, type_registry,
                 metadata.size, metadata
             ].pack("CVa#{name.size}Va#{type_name.size}Va#{type_registry.size}Va#{metadata.size}")
-	    write_block(wio, STREAM_BLOCK, index, payload)
+            write_block(wio, STREAM_BLOCK, index, payload)
         end
 
         # Helper method that makes sure to create new files if the current file
         # size is bigger than MAX_FILE_SIZE (if defined). 
-	def do_write # :nodoc:
+        def do_write # :nodoc:
             yield
-	    
-	    if defined?(MAX_FILE_SIZE) && (wio.tell > MAX_FILE_SIZE)
-		new_file
-	    end
-	end
+            
+            if defined?(MAX_FILE_SIZE) && (wio.tell > MAX_FILE_SIZE)
+                new_file
+            end
+        end
 
         # Writes a stream declaration to the current write IO
-	def write_stream_declaration(index, name, type, registry, metadata)
+        def write_stream_declaration(index, name, type, registry, metadata)
             do_write do
                 Logfiles.write_stream_declaration(wio, index, name, type, registry, metadata)
             end
-	end
+        end
 
         # Returns all streams of the given type. The type can be given by its
         # name or through a Typelib::Type subclass
@@ -902,32 +902,32 @@ module Pocolog
                 type = registry.get(type)
             end
 
-	    typename  = type.name
+            typename  = type.name
             registry = type.registry.minimal(type.name).to_xml
 
-	    @streams ||= Array.new
-	    new_index = @streams.size
-	    write_stream_declaration(new_index, name, type.name, registry, metadata)
+            @streams ||= Array.new
+            new_index = @streams.size
+            write_stream_declaration(new_index, name, type.name, registry, metadata)
 
-	    stream = DataStream.new(self, new_index, name, typename, registry, metadata)
-	    @streams << stream
-	    stream
+            stream = DataStream.new(self, new_index, name, typename, registry, metadata)
+            @streams << stream
+            stream
         end
 
-	# Returns the DataStream object for +name+, +registry+ and
-	# +type+. Optionally creates it.
+        # Returns the DataStream object for +name+, +registry+ and
+        # +type+. Optionally creates it.
         #
         # If +create+ is false, raises ArgumentError if the stream does not
         # exist.
-	def stream(name, type = nil, create = false)
-	    if s = streams.find { |s| s.name == name }
+        def stream(name, type = nil, create = false)
+            if s = streams.find { |s| s.name == name }
                 s.registry # load the registry NOW
-		return s
-	    elsif !type || !create
-		raise ArgumentError, "no such stream #{name}"
-	    end
+                return s
+            elsif !type || !create
+                raise ArgumentError, "no such stream #{name}"
+            end
             create_stream(name, type)
-	end
+        end
 
         # Returns true if +name+ is the name of an existing stream
         def has_stream?(name)
@@ -935,20 +935,20 @@ module Pocolog
         rescue ArgumentError
         end
 
-	# Creates a JointStream object on the streams whose names are given.
-	# The returned object is used to coherently iterate on the samples of
-	# the given streams (i.e. it will yield samples that are valid at the
-	# same time)
-	def joint_stream(use_rt, *names)
-	    streams = names.map do |n|
-		stream(n)
-	    end
-	    JointStream.new(use_rt, *streams)
-	end
+        # Creates a JointStream object on the streams whose names are given.
+        # The returned object is used to coherently iterate on the samples of
+        # the given streams (i.e. it will yield samples that are valid at the
+        # same time)
+        def joint_stream(use_rt, *names)
+            streams = names.map do |n|
+                stream(n)
+            end
+            JointStream.new(use_rt, *streams)
+        end
 
-	TIME_PADDING = TIME_SIZE - 8
+        TIME_PADDING = TIME_SIZE - 8
         # Formatting string for Array.pack to create a data block
-	DATA_BLOCK_HEADER_FORMAT = "VVx#{TIME_PADDING}VVx#{TIME_PADDING}VC"
+        DATA_BLOCK_HEADER_FORMAT = "VVx#{TIME_PADDING}VVx#{TIME_PADDING}VC"
 
         def self.write_data_block(io, stream_index, rt, lg, compress, data)
             payload = [rt.tv_sec, rt.tv_usec, lg.tv_sec, lg.tv_usec,
@@ -960,17 +960,17 @@ module Pocolog
         # Write a data block for stream index +stream+, with the provided times
         # and the given data. +data+ must already be marshalled (i.e. it is
         # meant to be a String that represents a byte array).
-	def write_data_block(stream, rt, lg, data) # :nodoc:
-	    compress = 0
-	    if compress? && data.size > COMPRESSION_MIN_SIZE
-		data = Zlib::Deflate.deflate(data)
-		compress = 1
-	    end
+        def write_data_block(stream, rt, lg, data) # :nodoc:
+            compress = 0
+            if compress? && data.size > COMPRESSION_MIN_SIZE
+                data = Zlib::Deflate.deflate(data)
+                compress = 1
+            end
 
             do_write do
                 Logfiles.write_data_block(wio, stream.index, rt, lg, compress, data)
             end
-	end
+        end
 
         # Creates a stream aligner on all streams of this logfile
         def stream_aligner(use_rt = false)

--- a/lib/pocolog/logger.rb
+++ b/lib/pocolog/logger.rb
@@ -1,85 +1,85 @@
 module Pocolog
     class Logger
-	Sampling = Struct.new :next_sample, :stream, :source, :period, :last_write
+        Sampling = Struct.new :next_sample, :stream, :source, :period, :last_write
 
-	attr_reader :mutex
-	attr_reader :output
-	attr_reader :on_demand
-	attr_reader :periodic
+        attr_reader :mutex
+        attr_reader :output
+        attr_reader :on_demand
+        attr_reader :periodic
 
-	# Create a new logger which will log into the +output+ Logfiles object.
-	def initialize(output)
-	    @mutex = Mutex.new 
-	    @on_demand = []
-	    @periodic  = []
-	    @output = output
-	end
+        # Create a new logger which will log into the +output+ Logfiles object.
+        def initialize(output)
+            @mutex = Mutex.new 
+            @on_demand = []
+            @periodic  = []
+            @output = output
+        end
 
-	def close
-	    @quit = true
-	    @logging_thread.join if @logging_thread
-	    output.close
-	end
+        def close
+            @quit = true
+            @logging_thread.join if @logging_thread
+            output.close
+        end
 
-	# Add a new source to load
-	def add(source, period)
-	    stream = output.stream source.full_name, source.type, true
+        # Add a new source to load
+        def add(source, period)
+            stream = output.stream source.full_name, source.type, true
 
-	    spec = Sampling.new(nil, stream, source, nil)
-	    if period == :on_demand
-		on_demand << spec
-	    else 
-		mutex.synchronize do
-		    spec.period      = Float(period)
-		    spec.next_sample = Time.now + spec.period
-		    periodic << spec
-		end
-	    end
-	end
+            spec = Sampling.new(nil, stream, source, nil)
+            if period == :on_demand
+                on_demand << spec
+            else 
+                mutex.synchronize do
+                    spec.period      = Float(period)
+                    spec.next_sample = Time.now + spec.period
+                    periodic << spec
+                end
+            end
+        end
 
-	def start
-	    @logging_thread = Thread.new do
-		while true
-		    break if @quit
-		    log_pending_sources
-		    sleep(periodic.first.next_sample - Time.now)
-		end
-	    end
-	end
+        def start
+            @logging_thread = Thread.new do
+                while true
+                    break if @quit
+                    log_pending_sources
+                    sleep(periodic.first.next_sample - Time.now)
+                end
+            end
+        end
 
-	def log_pending_sources
-	    while true
-		# Loop until there is no pending sample to write
-		mutex.synchronize do
-		    @periodic = periodic.sort_by { |spec| spec.next_sample }
-		    next_read = periodic.first
-		    return if next_read.next_sample > Time.now
-		end
+        def log_pending_sources
+            while true
+                # Loop until there is no pending sample to write
+                mutex.synchronize do
+                    @periodic = periodic.sort_by { |spec| spec.next_sample }
+                    next_read = periodic.first
+                    return if next_read.next_sample > Time.now
+                end
 
-		log_source(next_read)
-		next_read.next_sample += next_read.period
-	    end
-	end
+                log_source(next_read)
+                next_read.next_sample += next_read.period
+            end
+        end
 
-	def log_sample(spec, force = false)
-	    source = spec.source
-	    if force || (source.timestamp != spec.last_write)
-		spec.stream.write(Time.now, source.timestamp, source.read)
-		spec.last_write = source.timestamp
-	    end
-	end
+        def log_sample(spec, force = false)
+            source = spec.source
+            if force || (source.timestamp != spec.last_write)
+                spec.stream.write(Time.now, source.timestamp, source.read)
+                spec.last_write = source.timestamp
+            end
+        end
 
 
-	# Log all configured sources once, now.  If +force+ is true, read even
-	# if the sources have not been updated
-	def now(force = false)
-	    mutex.synchronize do
-		(on_demand + periodic).each do |spec|
-		    log_sample(spec, force)
-		end
-	    end
+        # Log all configured sources once, now.  If +force+ is true, read even
+        # if the sources have not been updated
+        def now(force = false)
+            mutex.synchronize do
+                (on_demand + periodic).each do |spec|
+                    log_sample(spec, force)
+                end
+            end
 
-	end
+        end
     end
 end
 

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -1,12 +1,12 @@
 module Pocolog
     class OutOfBounds < Exception;end
     class StreamAligner
-	attr_reader :use_rt
-	attr_reader :use_sample_time
+        attr_reader :use_rt
+        attr_reader :use_sample_time
 
         attr_reader :base_time
 
-	attr_reader :streams
+        attr_reader :streams
 
         # Provided for backward compatibility only
         def count_samples
@@ -48,7 +48,7 @@ module Pocolog
         #
         # @return [(Time,Time)]
         attr_reader :time_interval
-	
+
         def initialize(use_rt = false, *streams)
             @use_sample_time = use_rt == :use_sample_time
             @use_rt  = use_rt
@@ -62,7 +62,7 @@ module Pocolog
             rewind
         end
 
-	# Returns the time of the last played back sample
+        # Returns the time of the last played back sample
         #
         # @return [Time]
         def time
@@ -71,19 +71,19 @@ module Pocolog
             end
         end
 
-	# Tests whether reading the next sample will return something
+        # Tests whether reading the next sample will return something
         #
         # If {eof?} returns true, {#advance} and {#step} are guaranteed to return
         # nil if called.
         def eof?
-	    sample_index >= size - 1
+            sample_index >= size - 1
         end
 
         # Rewinds the stream aligner to the position before the first sample
         #
         # I.e. calling {#next} after {#rewind} would read the first sample
-	def rewind
-	    @sample_index = -1
+        def rewind
+            @sample_index = -1
             nil
         end
 
@@ -95,8 +95,8 @@ module Pocolog
         # attributes based on the information contained in the underlying
         # streams
         def build_index(streams)
-	    @size = streams.inject(0) { |s, stream| s + stream.size }
-	    Pocolog.info("got #{streams.size} streams with #{size} samples")
+            @size = streams.inject(0) { |s, stream| s + stream.size }
+            Pocolog.info("got #{streams.size} streams with #{size} samples")
             tic = Time.now
             @base_time = streams.map { |s| s.stream_index.base_time }.compact.min
 
@@ -125,36 +125,36 @@ module Pocolog
 
             Pocolog.info "built index in #{"%.2f" % [Time.now - tic]} seconds"
         end
-	
+
         # Seek at the given position or time
         #
         # @overload seek(pos, read_data = true)
         #   (see seek_to_pos)
         # @overload seek(time, read_data = true)
         #   (see seek_to_time)
-	def seek(pos, read_data = true)
-	    if pos.kind_of?(Time)
-		seek_to_time(pos, read_data)
-	    else
-		seek_to_pos(pos, read_data)
-	    end
-	end
-	
+        def seek(pos, read_data = true)
+            if pos.kind_of?(Time)
+                seek_to_time(pos, read_data)
+            else
+                seek_to_pos(pos, read_data)
+            end
+        end
+
         # Seek to the first sample after the given time
         #
         # @param [Time] time the reference time
         # @param [Boolean] read_data whether the sample itself should be read or not
         # @return [(Integer,Time[,Typelib::Type])] the stream index, sample time
         #   and the sample itself if read_data is true
-	def seek_to_time(time, read_data = true)
-            if(time < time_interval[0] || time > time_interval[1]) 
+        def seek_to_time(time, read_data = true)
+            if(time < time_interval[0] || time > time_interval[1])
                 raise RangeError, "#{time} is out of bounds valid interval #{time_interval[0]} to #{time_interval[1]}"
             end
-	    
+
             target_time = StreamIndex.time_to_internal(time, base_time)
-	    entry = @full_index.bsearch { |e| e.time >= target_time }
+            entry = @full_index.bsearch { |e| e.time >= target_time }
             seek_to_index_entry(entry, read_data)
-	end
+        end
 
         # Seeks to the sample whose global position is pos
         #
@@ -205,7 +205,7 @@ module Pocolog
         def stream_index_for_stream(stream)
             streams.index(stream)
         end
-            
+
         # Returns the stream index of the stream with this name
         #
         # @param [String] name
@@ -216,9 +216,9 @@ module Pocolog
                     return i
                 end
             end
-            return nil 
+            return nil
         end
-        
+
         # Returns the stream index of the stream whose type has this name
         #
         # @param [String] name
@@ -260,11 +260,11 @@ module Pocolog
         # @return [(Integer,Time)]
         # @see step
         def advance
-	    if eof?
-		@sample_index = size
-		return
-	    end
-	    
+            if eof?
+                @sample_index = size
+                return
+            end
+
             seek_to_pos(@sample_index + 1, false)
         end
 
@@ -273,12 +273,12 @@ module Pocolog
         #
         # @return [(Integer,Time,Typelib::Type)]
         def step_back
-	    if @sample_index == 0
-		@sample_index = -1
-		return nil
-	    end
-	    
-	    seek_to_pos(sample_index - 1)
+            if @sample_index == 0
+                @sample_index = -1
+                return nil
+            end
+
+            seek_to_pos(sample_index - 1)
         end
 
         # Defined for compatibility with DataStream#next
@@ -311,9 +311,9 @@ module Pocolog
             pp.text "next_samples:"
             pp.nest(2) do
                 pp.breakable
-		
+
                 pp.seplist(streams.each_index) do |i|
-		    ih = @stream_index_to_index_helpers[i]
+                    ih = @stream_index_to_index_helpers[i]
                     if ih
                         pp.text "#{i} #{ih.time.to_f}"
                     else
@@ -335,10 +335,10 @@ module Pocolog
             end
         end
 
-        # exports all streams to a new log file 
+        # exports all streams to a new log file
         # if no start and end index is given all data are exported
-        # otherwise the data are truncated according to the given global indexes 
-        # 
+        # otherwise the data are truncated according to the given global indexes
+        #
         # the block is called for each sample to update a custom progress bar if the block
         # returns 1 the export is canceled
         def export_to_file(file,start_index=0,end_index=size,&block)
@@ -354,7 +354,7 @@ module Pocolog
 
                 stream_start_index = [start_index, stream_start_index].max
                 stream_end_index   = [end_index, stream_end_index].min
-                
+
                 first_stream_pos = find_first_stream_sample_at_or_after(
                     stream_start_index, s)
                 last_stream_pos  = find_first_stream_sample_at_or_after(
@@ -367,7 +367,7 @@ module Pocolog
                 result = s.copy_to(first_stream_pos,last_stream_pos,stream_output) do |i|
                     if block
                         index +=1
-                        block.call(index,number_of_samples) 
+                        block.call(index,number_of_samples)
                     end
                 end
                 break if !result
@@ -448,7 +448,7 @@ module Pocolog
             if stream.kind_of?(DataStream)
                 stream = streams.index(stream)
             end
-            @global_pos_first_sample[stream] 
+            @global_pos_first_sample[stream]
         end
 
         # Returns the global sample position of the last sample of the given
@@ -480,14 +480,14 @@ module Pocolog
         #       stream.read_one_raw_data_sample(position)
         #    end
         def sample_info(stream_idx)
-	    if state = @stream_state[stream_idx]
-		return streams[stream_idx], state.position_in_stream
-	    end
+            if state = @stream_state[stream_idx]
+                return streams[stream_idx], state.position_in_stream
+            end
         end
 
         # Returns the current data sample for the given stream index
-	# note stream index is the index of the data stream, not the 
-	# search index !
+        # note stream index is the index of the data stream, not the
+        # search index !
         #
         # @param [Integer] index index of the stream
         # @param [Typelib::Type,nil] sample if given, the sample will be decoded
@@ -500,8 +500,8 @@ module Pocolog
         end
 
         # Returns the current raw data sample for the given stream index
-	# note stream index is the index of the data stream, not the 
-	# search index !
+        # note stream index is the index of the data stream, not the
+        # search index !
         #
         # @param [Integer] index index of the stream
         # @param [Typelib::Type,nil] sample if given, the sample will be decoded
@@ -511,7 +511,7 @@ module Pocolog
             stream, position = sample_info(index)
             if stream
                 stream.read_one_raw_data_sample(position)
-	    end
+            end
         end
 
         # Enumerate all samples in this stream

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -105,7 +105,7 @@ module Pocolog
 
             full_index = Array.new
             streams.each_with_index do |stream, i|
-                stream.stream_index.base_time = base_time
+                stream.stream_index.base_time = base_time if base_time
                 stream.stream_index.time_to_position_map.each do |time, position|
                     full_index << [time, i, position]
                 end

--- a/lib/pocolog/stream_index.rb
+++ b/lib/pocolog/stream_index.rb
@@ -40,26 +40,26 @@ module Pocolog
             @base_time = nil
             @time_to_position_map = Array.new()
             @nr_to_rio = Array.new()
-	end
-	
-	#adds a given sample header (and thus the sample) to
-	#the index
-	def add_sample_to_index(rio, pos, time)
-	    #store the posiiton of the header of the data sample
-	    @nr_to_rio << rio
-	    @nr_to_position_map << pos 
+        end
+        
+        #adds a given sample header (and thus the sample) to
+        #the index
+        def add_sample_to_index(rio, pos, time)
+            #store the posiiton of the header of the data sample
+            @nr_to_rio << rio
+            @nr_to_position_map << pos 
             internal_time = time.tv_sec * 1_000_000 + time.tv_usec
             @base_time ||= internal_time
             @time_to_position_map << [(internal_time - @base_time), time_to_position_map.size]
-	end
+        end
 
-	# sanity check for the index, which gets called after
-	# marshalling, to see if the index needs rebuilding
-	def sane?
-	    @nr_to_rio && @nr_to_position_map && @time_to_position_map &&
-	    @nr_to_rio.size == @nr_to_position_map.size &&
-	    @nr_to_rio.size == @time_to_position_map.size
-	end
+        # sanity check for the index, which gets called after
+        # marshalling, to see if the index needs rebuilding
+        def sane?
+            @nr_to_rio && @nr_to_position_map && @time_to_position_map &&
+            @nr_to_rio.size == @nr_to_position_map.size &&
+            @nr_to_rio.size == @time_to_position_map.size
+        end
 
         def self.time_from_internal(time, base_time)
             time = time + base_time
@@ -75,7 +75,7 @@ module Pocolog
         # the given time
         #
         # @param [Time]
-	def sample_number_by_time(sample_time)
+        def sample_number_by_time(sample_time)
             sample_time = StreamIndex.time_to_internal(sample_time, base_time)
             sample_number_by_internal_time(sample_time)
         end
@@ -87,26 +87,26 @@ module Pocolog
         def sample_number_by_internal_time(sample_time)
             _, idx = @time_to_position_map.bsearch { |t, _| t >= sample_time }
             idx || size
-	end
-	
-	# Expects the number of the sample that needs to be accessed 
-	# and returns the position of the sample in the file
-	def file_position_by_sample_number(sample_nr)
-	    return @nr_to_rio[sample_nr], @nr_to_position_map[sample_nr]
-	end
+        end
+        
+        # Expects the number of the sample that needs to be accessed 
+        # and returns the position of the sample in the file
+        def file_position_by_sample_number(sample_nr)
+            return @nr_to_rio[sample_nr], @nr_to_position_map[sample_nr]
+        end
 
         def internal_time_by_sample_number(sample_nr)
-	    if(sample_nr < 0 || sample_nr >= size)
-		raise ArgumentError, "#{sample_nr} out of bounds"
-	    end
+            if(sample_nr < 0 || sample_nr >= size)
+                raise ArgumentError, "#{sample_nr} out of bounds"
+            end
             @time_to_position_map[sample_nr].first
         end
 
-	# expects a sample nr and returns the time
-	# of the sample
+        # expects a sample nr and returns the time
+        # of the sample
         def time_by_sample_number(sample_nr)
-	    StreamIndex.time_from_internal(internal_time_by_sample_number(sample_nr), base_time)
-	end
+            StreamIndex.time_from_internal(internal_time_by_sample_number(sample_nr), base_time)
+        end
 
         def marshal_dump
             [@nr_to_rio.pack("n*"),

--- a/test/test_stream_aligner.rb
+++ b/test/test_stream_aligner.rb
@@ -206,6 +206,17 @@ module Pocolog
             assert_equal [1, Time.at(3*10)], aligner.seek_to_pos(4, false)
         end
 
+        it "successfully aligns empty streams" do
+            aligner, _s0, s1 = create_aligner([1, 2], [])
+            assert aligner.stream_index_for_stream(s1)
+        end
+
+        it "successfully aligns a set of completely empty streams" do
+            aligner, s0, s1 = create_aligner([], [])
+            assert aligner.stream_index_for_stream(s0)
+            assert aligner.stream_index_for_stream(s1)
+        end
+
         describe "#find_first_stream_sample_after" do
 
             it "returns the stream-local position of the next sample if the global positition points to a sample of the expected stream" do

--- a/test/test_stream_aligner.rb
+++ b/test/test_stream_aligner.rb
@@ -46,29 +46,29 @@ class TC_StreamAligner < Minitest::Test
     end
 
     def test_eof_is_a_valid_loop_termination_condition
-	while !@stream.eof?
-	    index = stream.step
+        while !@stream.eof?
+            index = stream.step
             assert index, "failed at #{stream.sample_index}"
         end
     end
 
     def test_time_advancing
-	cnt = 0
+        cnt = 0
         last_time = nil
-	while !@stream.eof?
-	    index, time, data = stream.step
+        while !@stream.eof?
+            index, time, data = stream.step
             assert(!last_time || last_time < time)
             last_time = time
-	    cnt = cnt + 1
-	end
+            cnt = cnt + 1
+        end
         last_time = nil
         stream.step
-	while cnt > 0
-	    index, time, data = stream.step_back()
-	    assert(!last_time || last_time > time)
-	    cnt = cnt - 1
-	    last_time = time
-	end	
+        while cnt > 0
+            index, time, data = stream.step_back()
+            assert(!last_time || last_time > time)
+            cnt = cnt - 1
+            last_time = time
+        end     
     end
     
     def test_step_by_step_all_the_way
@@ -94,7 +94,7 @@ class TC_StreamAligner < Minitest::Test
                 sample_indexes << stream.sample_index
                 all_data << data[2]
             end
-	    
+            
             assert_equal interleaved_data, all_data.reverse
             assert_equal [[0, 2, 0, 1]].to_set, stream_indexes.reverse.each_slice(4).to_set
             assert_equal (0...200).to_a, sample_indexes.reverse

--- a/test/test_stream_aligner2.rb
+++ b/test/test_stream_aligner2.rb
@@ -18,7 +18,7 @@ class TC_StreamAligner2 < Minitest::Test
         # case in #test_past_the_end_does_not_read_whole_file
         other_stream = logfile.create_stream('other', 'int')
         100.times do |i|
-	    i = i + 100
+            i = i + 100
             other_stream.write(Time.at(i), Time.at(i * 100), i)
             expected_data << i
         end
@@ -44,58 +44,58 @@ class TC_StreamAligner2 < Minitest::Test
 
 
     def test_start_of_stream
-	index, time, data = stream.step()
-	assert_equal index, 0
-	assert_equal data, expected_data[0]
-	assert_equal time, Time.at(expected_data[0] * 100)
+        index, time, data = stream.step()
+        assert_equal index, 0
+        assert_equal data, expected_data[0]
+        assert_equal time, Time.at(expected_data[0] * 100)
     end
 
     def test_full_replay
-	cnt = 0
-	while(!stream.eof?)
-	    stream_index, time, data = stream.step()
-	    if(cnt < 100)
-		assert_equal stream_index, 0
-	    else
-		assert_equal stream_index, 1
-	    end
-	    assert_equal data, expected_data[cnt]
-	    assert_equal time, Time.at(expected_data[cnt] * 100)
-	    cnt = cnt + 1
-	end
-	
-	assert_equal cnt, 200
+        cnt = 0
+        while(!stream.eof?)
+            stream_index, time, data = stream.step()
+            if(cnt < 100)
+                assert_equal stream_index, 0
+            else
+                assert_equal stream_index, 1
+            end
+            assert_equal data, expected_data[cnt]
+            assert_equal time, Time.at(expected_data[cnt] * 100)
+            cnt = cnt + 1
+        end
+        
+        assert_equal cnt, 200
     end
 
     def test_forward_backward
-	cnt = 0
-	while(!stream.eof?)
-	    stream_index, time, data = stream.step()
-	    if(cnt < 100)
-		assert_equal stream_index, 0
-	    else
-		assert_equal stream_index, 1
-	    end
-	    assert_equal data, expected_data[cnt]
-	    assert_equal time, Time.at(expected_data[cnt] * 100)
-	    cnt = cnt + 1
-	end
-	
-	assert_equal cnt, 200
-	cnt = cnt - 1
-	
-	while(cnt > 1)
-	    cnt = cnt - 1
-	    stream_index, time, data = stream.step_back()
-	    if(cnt < 100)
-		assert_equal stream_index, 0
-	    else
-		assert_equal stream_index, 1
-	    end
-	    assert_equal data, expected_data[cnt]
-	    assert_equal time, Time.at(expected_data[cnt] * 100)
-	end	    
-	
+        cnt = 0
+        while(!stream.eof?)
+            stream_index, time, data = stream.step()
+            if(cnt < 100)
+                assert_equal stream_index, 0
+            else
+                assert_equal stream_index, 1
+            end
+            assert_equal data, expected_data[cnt]
+            assert_equal time, Time.at(expected_data[cnt] * 100)
+            cnt = cnt + 1
+        end
+        
+        assert_equal cnt, 200
+        cnt = cnt - 1
+        
+        while(cnt > 1)
+            cnt = cnt - 1
+            stream_index, time, data = stream.step_back()
+            if(cnt < 100)
+                assert_equal stream_index, 0
+            else
+                assert_equal stream_index, 1
+            end
+            assert_equal data, expected_data[cnt]
+            assert_equal time, Time.at(expected_data[cnt] * 100)
+        end         
+        
     end
 
     def test_export_to_file
@@ -118,17 +118,17 @@ class TC_StreamAligner2 < Minitest::Test
         assert_equal 20, stream2.size
 
         cnt = 0
-	while(!stream2.eof?)
-	    stream_index, time, data = stream2.step()
-	    if(cnt < 10)
-		assert_equal stream_index, 0
-	    else
-		assert_equal stream_index, 1
-	    end
-	    assert_equal data, expected_data[cnt+90]
-	    assert_equal time, Time.at(expected_data[cnt+90] * 100)
-	    cnt = cnt + 1
-	end
+        while(!stream2.eof?)
+            stream_index, time, data = stream2.step()
+            if(cnt < 10)
+                assert_equal stream_index, 0
+            else
+                assert_equal stream_index, 1
+            end
+            assert_equal data, expected_data[cnt+90]
+            assert_equal time, Time.at(expected_data[cnt+90] * 100)
+            cnt = cnt + 1
+        end
         logfile2.close
 
     ensure


### PR DESCRIPTION
In general, there's no reason to not support this corner case.
In particular, Vizkit actually calls the aligner "as if" the
empty streams were aligned, but orocos/log skips the empty
streams. While this "magically" works now, there's not reason
it should - the refactored pocolog will raise if an unknown
stream is queried.