### PR TITLE
allow disabling colors and progress bar in TTYReporter

### DIFF
--- a/bin/pocolog-repair
+++ b/bin/pocolog-repair
@@ -6,7 +6,7 @@ require 'pocolog'
 require 'pocolog/repair'
 require 'pocolog/cli/tty_reporter'
 
-reporter = Pocolog::CLI::TTYReporter.new("[:bar]", total: 0)
+reporter = Pocolog::CLI::TTYReporter.new('[:bar]', total: 0)
 ARGV.each do |path|
     reporter.info "Processing #{path} ..."
     Pocolog.repair_file(path, reporter: reporter)

--- a/lib/pocolog/cli/tty_reporter.rb
+++ b/lib/pocolog/cli/tty_reporter.rb
@@ -18,10 +18,11 @@ module Pocolog
             # underlying progress handler
             attr_accessor :base
 
-            def initialize(format, **options)
+            def initialize(format, colors: true, progress: true, **options)
                 @base = 0
+                @progress_enabled = progress
                 reset_progressbar(format, **options)
-                pastel = Pastel.new
+                pastel = Pastel.new(enabled: colors)
                 @c_warn = pastel.yellow.detach
                 @c_info = pastel.yellow.detach
                 @c_error = pastel.bright_red.detach
@@ -29,13 +30,15 @@ module Pocolog
             end
 
             def reset_progressbar(format, **options)
+                return unless @progress_enabled
+
                 progress_bar.reset if @progress_bar
                 @progress_bar = TTY::ProgressBar.new(format, **options)
                 progress_bar.resize(60)
             end
 
             def log(msg)
-                if progress_bar.send(:tty?)
+                if progress_bar&.send(:tty?)
                     progress_bar.log(msg)
                 else
                     $stdout.puts(msg)
@@ -43,14 +46,20 @@ module Pocolog
             end
 
             def current
+                return unless @progress_enabled
+
                 progress_bar.current - base
             end
 
             def current=(value)
+                return unless @progress_enabled
+
                 progress_bar.current = value + base
             end
 
             def advance(step = 1)
+                return unless @progress_enabled
+
                 progress_bar.advance(step)
             end
 
@@ -71,6 +80,8 @@ module Pocolog
             end
 
             def finish
+                return unless @progress_enabled
+
                 progress_bar.finish
             end
         end

--- a/lib/pocolog/format/v2.rb
+++ b/lib/pocolog/format/v2.rb
@@ -150,7 +150,8 @@ module Pocolog
                               "(#{expected_mtime_i}) mismatch"
                     end
                 end
-                [index_version, index_size, StreamIndex.time_from_internal(index_mtime, 0)]
+                [index_version, index_size,
+                 StreamIndex.time_from_internal(index_mtime, 0)]
             end
 
             # Write a prologue on an index file

--- a/lib/pocolog/repair.rb
+++ b/lib/pocolog/repair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pocolog/cli/null_reporter'
 
 module Pocolog

--- a/test/repair_test.rb
+++ b/test/repair_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'test_helper'
 require 'pocolog/repair'
 


### PR DESCRIPTION
Important for unit tests, to avoid having to test against the color
scheme