### PR TITLE
small additional tool for log rewrite

### DIFF
--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -237,6 +237,17 @@ module Pocolog
             def metadata
                 @metadata ||= YAML.safe_load(metadata_yaml)
             end
+
+            # Return the encoded (on-disk) representation of this stream definition
+            def encode # rubocop:disable Metrics/AbcSize
+                [
+                    DATA_STREAM, name.size, name,
+                    typename.size, typename,
+                    registry_xml.size, registry_xml,
+                    metadata_yaml.size, metadata_yaml
+                ].pack("CVa#{name.size}Va#{typename.size}"\
+                       "Va#{registry_xml.size}Va#{metadata_yaml.size}")
+            end
         end
 
         def self.read_stream_block(io, pos = nil)

--- a/lib/pocolog/data_stream.rb
+++ b/lib/pocolog/data_stream.rb
@@ -15,7 +15,7 @@ module Pocolog
         # until it returned nil
         attr_reader :sample_index
         # The stream associated metadata
-        attr_reader :metadata
+        attr_accessor :metadata
 
         def typename
             type.name
@@ -25,7 +25,8 @@ module Pocolog
             type.name
         end
 
-        def initialize(logfile, index, name, stream_type, metadata = Hash.new, info = StreamInfo.new)
+        def initialize(logfile, index, name, stream_type,
+                       metadata = {}, info = StreamInfo.new)
             @logfile, @index, @name, @metadata, @info =
                 logfile, index, name, metadata, info
 


### PR DESCRIPTION
This allows to change and re-encode a stream declaration while rewriting a log (specifically, normalize its metadata when some bugs are found in metadata generation)