### PR TITLE
add methods to truncate and resample data streams

### DIFF
--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -156,6 +156,7 @@ module Pocolog
                 @full_index[position_global] = entry
                 position_global += 1
             end
+
             @streams = all_streams
             update_interval_lg
             Pocolog.info "built full index in #{"%.2f" % [Time.now - tic]} seconds"
@@ -623,7 +624,7 @@ module Pocolog
         #   in this object instead of creating a new one
         # @return [Object,nil]
         def single_data(index, sample = nil)
-            if raw = single_raw_data(index, sample)
+            if (raw = single_raw_data(index, sample))
                 return Typelib.to_ruby(raw)
             end
         end

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -651,15 +651,28 @@ module Pocolog
         #   contained
         # @yieldparam [Time] time the stream time
         # @yieldparam [Object] sample the sample itself
-        def each(do_rewind = true)
-            return enum_for(__method__, do_rewind) if !block_given?
-            if do_rewind
-                rewind
+        def raw_each(do_rewind = true)
+            return enum_for(__method__, do_rewind) unless block_given?
+
+            rewind if do_rewind
+            while (stream_idx, time = advance)
+                yield(stream_idx, time, single_raw_data(stream_idx))
             end
-            while sample = self.step
-                yield(*sample)
+        end
+
+        # Enumerate all samples in this stream
+        #
+        # @param [Boolean] do_rewind whether {#rewind} should be called first
+        # @yieldparam [Integer] stream_idx the stream in which the sample is
+        #   contained
+        # @yieldparam [Time] time the stream time
+        # @yieldparam [Object] sample the sample itself
+        def each(do_rewind = true)
+            return enum_for(__method__, do_rewind) unless block_given?
+
+            raw_each(do_rewind) do |index, time, raw_sample|
+                yield(index, time, Typelib.to_ruby(raw_sample))
             end
         end
     end
 end
-

--- a/test/data_stream_test.rb
+++ b/test/data_stream_test.rb
@@ -520,6 +520,12 @@ module Pocolog
                 assert_equal [[base_time + 1, base_time + 11, 1],
                               [base_time + 2, base_time + 12, 2]], stream.each.to_a
             end
+
+            it "updates the stream index of the returned stream" do
+                stream = @stream.from_logical_time(base_time + 10.1)
+                assert_equal [base_time + 1, base_time + 11, 1],
+                             stream.seek(base_time + 11)
+            end
         end
 
         describe "#to_logical_time" do
@@ -547,6 +553,12 @@ module Pocolog
                 assert_equal [[base_time + 0, base_time + 10, 0],
                               [base_time + 1, base_time + 11, 1]], stream.each.to_a
             end
+
+            it "updates the stream index of the returned stream" do
+                stream = @stream.to_logical_time(base_time + 12)
+                assert_equal [base_time + 1, base_time + 11, 1],
+                             stream.seek(base_time + 11)
+            end
         end
 
         describe "#resample_by_index" do
@@ -568,6 +580,12 @@ module Pocolog
                               [base_time + 3, base_time + 13, 3],
                               [base_time + 6, base_time + 16, 6],
                               [base_time + 9, base_time + 19, 9]], stream.each.to_a
+            end
+
+            it "updates the stream index of the returned stream" do
+                stream = @stream.resample_by_index(3)
+                assert_equal [base_time + 3, base_time + 13, 3],
+                             stream.seek(base_time + 11)
             end
         end
 
@@ -593,6 +611,12 @@ module Pocolog
                               [base_time + 6, base_time + 16, 6],
                               [base_time + 8, base_time + 18, 8],
                               [base_time + 9, base_time + 19, 9]], stream.each.to_a
+            end
+
+            it "updates the stream index of the returned stream" do
+                stream = @stream.resample_by_time(1.5)
+                assert_equal [base_time + 2, base_time + 12, 2],
+                             stream.seek(base_time + 11)
             end
         end
     end

--- a/test/stream_aligner_test.rb
+++ b/test/stream_aligner_test.rb
@@ -431,6 +431,35 @@ module Pocolog
             end
         end
 
+        describe "#raw_each" do
+            it "enumerates the stream index, logical time and raw sample data" do
+                aligner, _s0, _s1 = create_aligner([1, 3], [2, 4])
+                expected = [
+                    [0, Time.at(10), 1],
+                    [1, Time.at(20), 2],
+                    [0, Time.at(30), 3],
+                    [1, Time.at(40), 4]
+                ]
+                assert_equal(
+                    expected,
+                    aligner.raw_each.map { |i, t, s| [i, t, s.to_ruby] }
+                )
+            end
+        end
+
+        describe "#each" do
+            it "enumerates the stream index, logical time and converted sample data" do
+                aligner, _s0, _s1 = create_aligner([1, 3], [2, 4])
+                expected = [
+                    [0, Time.at(10), 1],
+                    [1, Time.at(20), 2],
+                    [0, Time.at(30), 3],
+                    [1, Time.at(40), 4]
+                ]
+                assert_equal expected, aligner.each.to_a
+            end
+        end
+
         describe "#next" do
             it "returns realtime, logical time and the (stream_index, data) tuple as sample" do
                 aligner, _s0, _s1 = create_aligner([1, 3], [2, 4])
@@ -442,6 +471,7 @@ module Pocolog
                 assert !aligner.next
             end
         end
+
         describe "#previous" do
             it "returns realtime, logical time and the (stream_index, data) tuple as sample" do
                 aligner, _s0, _s1 = create_aligner([1, 3], [2, 4])
@@ -529,9 +559,9 @@ class TC_StreamAligner < Minitest::Test
             assert(!last_time || last_time > time)
             cnt = cnt - 1
             last_time = time
-        end     
+        end
     end
-    
+
     def test_step_by_step_all_the_way
         2.times do
             stream_indexes, sample_indexes, all_data = Array.new, Array.new, Array.new
@@ -541,7 +571,7 @@ class TC_StreamAligner < Minitest::Test
                 all_data << data[2]
             end
             # verify that calling #step again is harmless
-            assert !stream.step 
+            assert !stream.step
             assert stream.eof?
             assert_equal 200, stream.sample_index
             assert_equal interleaved_data, all_data
@@ -555,13 +585,13 @@ class TC_StreamAligner < Minitest::Test
                 sample_indexes << stream.sample_index
                 all_data << data[2]
             end
-            
+
             assert_equal interleaved_data, all_data.reverse
             assert_equal [[0, 2, 0, 1]].to_set, stream_indexes.reverse.each_slice(4).to_set
             assert_equal (0...200).to_a, sample_indexes.reverse
         end
     end
-    
+
     # Checks that stepping and stepping back in the middle of the stream works
     # fine
     def test_step_by_step_middle
@@ -581,7 +611,7 @@ class TC_StreamAligner < Minitest::Test
         assert_equal 10, stream.sample_index
         assert_equal Time.at(5), stream.time
         assert_equal [0, Time.at(5), 5], sample
-        
+
         # Check that seeking did not break step / step_back
         assert_equal [1, Time.at(5, 500), 50000], stream.step
         assert_equal [0, Time.at(6), 6], stream.step
@@ -591,7 +621,7 @@ class TC_StreamAligner < Minitest::Test
         assert_equal [0, Time.at(4), 4], stream.step_back
         assert_equal [1, Time.at(3, 500), 30000], stream.step_back
 
-        #check if seeking is working if index is not cached 
+        #check if seeking is working if index is not cached
         #see INDEX_STEP
         sample = stream.seek(21)
         assert_equal 21, stream.sample_index
@@ -653,14 +683,14 @@ class TC_StreamAligner2 < Minitest::Test
         end
         logfile.close
     end
-    
+
     attr_reader :interleaved_data
     def setup
         create_fixture
         @logfile = Pocolog::Logfiles.open('test.0.log')
         @stream  = Pocolog::StreamAligner.new(false, logfile.stream('all'), logfile.stream('other'))
     end
-    
+
     def teardown
         FileUtils.rm_f 'test.0.log'
         FileUtils.rm_f 'test.0.idx'
@@ -692,7 +722,7 @@ class TC_StreamAligner2 < Minitest::Test
             assert_equal time, Time.at(expected_data[cnt] * 100)
             cnt = cnt + 1
         end
-        
+
         assert_equal cnt, 200
     end
 
@@ -709,10 +739,10 @@ class TC_StreamAligner2 < Minitest::Test
             assert_equal time, Time.at(expected_data[cnt] * 100)
             cnt = cnt + 1
         end
-        
+
         assert_equal cnt, 200
         cnt = cnt - 1
-        
+
         while(cnt > 1)
             cnt = cnt - 1
             stream_index, time, data = stream.step_back()
@@ -723,8 +753,8 @@ class TC_StreamAligner2 < Minitest::Test
             end
             assert_equal data, expected_data[cnt]
             assert_equal time, Time.at(expected_data[cnt] * 100)
-        end         
-        
+        end
+
     end
 
     def test_export_to_file


### PR DESCRIPTION
This pull request implements `from_logical_time`, `to_logical_time`, `resample_by_index` and `resample_by_time` on DataStream. These methods provide the same functionality that is currently provided by SampleEnumerator, but always through DataStream objects. This makes it compatible with the stream aligner, and also provide a major speedup in a lot of cases (since SampleEnumerator will always enumerate all samples, it's not very hard)