### PR TITLE
perf: flatten StreamIndex's internal data structure

### DIFF
--- a/bin/pocolog
+++ b/bin/pocolog
@@ -10,7 +10,7 @@ require 'time'
 def time_from_spec(spec)
     if spec =~ /^\d+$/ then Integer(spec)
     elsif spec =~ /^\d+\.\d+$/ then Time.at(Float(spec))
-    else Time.parse(spec) 
+    else Time.parse(spec)
     end
 end
 
@@ -21,7 +21,8 @@ Typelib.load_type_plugins = false
 # by a DisplayConfig instance
 module Pocolog
     class ModeConfig
-	attr_reader :io
+        attr_reader :io
+
         def initialize(io, index_dir: nil)
             @io = io
             @index_dir = index_dir
@@ -29,108 +30,82 @@ module Pocolog
     end
 
     class BaseCopyConfig < ModeConfig
-	attr_reader :output
-	def output=(file)
-	    if io.empty?
-		raise ArgumentError, "no input file given"
-	    end
-	    @output = file
-	end
+        attr_reader :output
+        def output=(file)
+            if io.empty?
+                raise ArgumentError, "no input file given"
+            end
+            @output = file
+        end
 
-	def self.single_io?; true end
-	def initialize(io)
-	    if io.size > 1 && self.class.single_io?
-		raise ArgumentError, "too much input files given on command line"
-	    end
-	    super
-	end
+        def self.single_io?; true end
+        def initialize(io)
+            if io.size > 1 && self.class.single_io?
+                raise ArgumentError, "too much input files given on command line"
+            end
 
-	def init(&block)
-	    if io.any? { |input| input.path == output }
-		# Special case ... generate a temporary file and move the file
-		# only when we're done
-		begin
-		    save_output = @output
-		    @output = "#{@output}.log"
-		    init(&block)
+            super
+        end
 
-		    FileUtils.rm_f save_output
-		    FileUtils.mv output, save_output
-		    return
-		rescue
-		    FileUtils.rm_f output
-		    raise
-		end
-	    end
+        def init(&block)
+            if io.any? { |input| input.path == output }
+                # Special case ... generate a temporary file and move the file
+                # only when we're done
+                begin
+                    save_output = @output
+                    @output = "#{@output}.log"
+                    init(&block)
 
-	    File.open(output, 'w', :encoding => 'BINARY') do |to|
-		if self.class.single_io?
-		    yield(io.first, to)
-		else
-		    yield(io, to)
-		end
-	    end
-	end
+                    FileUtils.rm_f save_output
+                    FileUtils.mv output, save_output
+                    return
+                rescue
+                    FileUtils.rm_f output
+                    raise
+                end
+            end
+
+            File.open(output, 'w', :encoding => 'BINARY') do |to|
+                if self.class.single_io?
+                    yield(io.first, to)
+                else
+                    yield(io, to)
+                end
+            end
+        end
     end
 
     class ToNewFormatConfig < BaseCopyConfig
-	def self.optname; "--to-new-format" end
-	attr_reader :big_endian
+        def self.optname; "--to-new-format" end
+        attr_reader :big_endian
 
-	# For #convert, specifies the byte order of the original file. This is
-	# needed for v1 files. See also #big_endian.
-	def little_endian
-	    @big_endian = false
-	end
+        # For #convert, specifies the byte order of the original file. This is
+        # needed for v1 files. See also #big_endian.
+        def little_endian
+            @big_endian = false
+        end
 
-	# For #convert, specifies the byte order of the original file. This is
-	# needed for v1 files. See also #little_endian.
-	def big_endian
-	    @big_endian = true
-	end
+        # For #convert, specifies the byte order of the original file. This is
+        # needed for v1 files. See also #little_endian.
+        def big_endian
+            @big_endian = true
+        end
 
-	def execute
-	    init { |from, to| Logfiles.to_new_format(from, to, @big_endian) }
-	end
+        def execute
+            init { |from, to| Logfiles.to_new_format(from, to, @big_endian) }
+        end
     end
     class CompressConfig < BaseCopyConfig
-	def self.optname; "--compress" end
-	def execute
-	    init { |from, to| Logfiles.compress(from, to) }
-	end
+        def self.optname; "--compress" end
+        def execute
+            init { |from, to| Logfiles.compress(from, to) }
+        end
     end
 
     class SampleModeConfig < ModeConfig
-	attr_reader :logfiles
-	attr_reader :specs
+        attr_reader :logfiles
+        attr_reader :specs
 
-	def current; specs.last end
-
-	def stream(name)
-	    unless s = logfiles.streams.find { |n| n.name == name }
-		raise ArgumentError, "no such stream #{name}"
-	    end
-	    unless s.type
-		raise ArgumentError, "no type definition found for #{name}"
-	    end
-	    specs << (spec = self.class::Spec.new(s.samples))
-	    if @default_at
-		spec.samples.at(@default_at)
-	    end
-	end
-
-	def at(value)
-	    @default_at = value
-	    super if current
-	end
-
-	def method_missing(name, *args, &block)
-	    if current.respond_to?(name)
-		current.send(name, *args)
-	    else
-		current.samples.send(name, *args)
-	    end
-	end
         def initialize(io, index_dir: nil)
             super
 
@@ -138,23 +113,51 @@ module Pocolog
             @specs      = []
         end
 
+        def current; specs.last end
+
+        def stream(name)
+            unless s = logfiles.streams.find { |n| n.name == name }
+                raise ArgumentError, "no such stream #{name}"
+            end
+            unless s.type
+                raise ArgumentError, "no type definition found for #{name}"
+            end
+            specs << (spec = self.class::Spec.new(s.samples))
+            if @default_at
+                spec.samples.at(@default_at)
+            end
+        end
+
+        def at(value)
+            @default_at = value
+            super if current
+        end
+
+        def method_missing(name, *args, &block)
+            if current.respond_to?(name)
+                current.send(name, *args)
+            else
+                current.samples.send(name, *args)
+            end
+        end
+
     end
 
     class ExtractConfig < BaseCopyConfig
-	def self.optname; "--extract" end
+        def self.optname; "--extract" end
 
-	def self.single_io?; false end
-	attr_accessor :streams
+        def self.single_io?; false end
+        attr_accessor :streams
         def initialize(io, index_dir: nil)
             super
             @streams = Hash.new
         end
 
-	def execute
-	    buffer = ""
-	    init do |from, to|
+        def execute
+            buffer = ""
+            init do |from, to|
                 Logfiles.write_prologue(to, Pocolog.big_endian?)
-                
+
                 next_index = 0
                 enabled = Hash.new
                 sample_count = Array.new
@@ -201,33 +204,33 @@ module Pocolog
                         end
                     end
                 end
-	    end
-	end
+            end
+        end
     end
 
     class TypeConfig < ModeConfig
-	def self.optname; "--type" end
-	attr_reader :logfiles
+        def self.optname; "--type" end
+        attr_reader :logfiles
         def initialize(io, index_dir: nil)
             super
             @logfiles   = Logfiles.new(*io, index_dir: index_dir)
         end
 
-	def execute
-	    logfiles.streams.each do |stream|
-		next unless stream.type
-		if type = stream.type.registry.get(@typename)
-		    pp type
-		    return
-		end
-	    end
+        def execute
+            logfiles.streams.each do |stream|
+                next unless stream.type
+                if type = stream.type.registry.get(@typename)
+                    pp type
+                    return
+                end
+            end
 
-	    # Try harder
-	end
+            # Try harder
+        end
 
-	def typename(name)
-	    @typename = name
-	end
+        def typename(name)
+            @typename = name
+        end
     end
 
 
@@ -265,10 +268,10 @@ module Pocolog
             eval "self.expr = Proc.new { |sample| #{string} }"
         end
 
-	def execute
-	    stream = samples.stream
+        def execute
+            stream = samples.stream
 
-	    if !expr && fields
+            if !expr && fields
                 field_operations = fields.map do |name|
                     ops = []
                     name.split('.').each do |subname|
@@ -293,7 +296,7 @@ module Pocolog
                     [name, ops]
                 end
 
-		header_names = field_operations.map do |name, field_ops| 
+                header_names = field_operations.map do |name, field_ops|
                     type = field_ops.inject(stream.type) do |type, op|
                         if op[0] == :deference
                             type.deference
@@ -305,37 +308,37 @@ module Pocolog
                             end
                         end
                     end
-		    subnames = type.to_csv
-		    name + subnames.gsub(/ \./, " #{name}.")
-		end
+                    subnames = type.to_csv
+                    name + subnames.gsub(/ \./, " #{name}.")
+                end
                 if time
                     header_names.unshift time
                 end
-		puts header_names.join(" ")
+                puts header_names.join(" ")
 
             elsif !expr
-		header = stream.type.to_csv(stream.name)
-		field_names = header.split(' ')
-		if remove_prefix
-		    field_names.map! { |name| name.gsub!(remove_prefix, '') if name }
-		end
-		if filter || filter_out
-		    field_indexes = field_names.enum_with_index.map do |field, index|
-			if filter_out && filter_out === field then nil
-			elsif filter && !(filter === field) then nil
-			else index
-			end
-		    end.compact
+                header = stream.type.to_csv(stream.name)
+                field_names = header.split(' ')
+                if remove_prefix
+                    field_names.map! { |name| name.gsub!(remove_prefix, '') if name }
+                end
+                if filter || filter_out
+                    field_indexes = field_names.enum_with_index.map do |field, index|
+                        if filter_out && filter_out === field then nil
+                        elsif filter && !(filter === field) then nil
+                        else index
+                        end
+                    end.compact
                     field_names = field_names.values_at(*field_indexes).join(" ")
                 end
                 if time
                     field_names.unshift('time')
                 end
                 puts field_names.join(' ')
-	    end
+            end
 
-	    samples.raw_each do |rt, lg, data|
-		if time
+            samples.raw_each do |rt, lg, data|
+                if time
                     if user_readable_time
                         if samples.use_rt
                             print rt.strftime("%H:%M:%S.%6N ")
@@ -349,62 +352,62 @@ module Pocolog
                             print "%i.%06i " % [lg.tv_sec, lg.tv_usec]
                         end
                     end
-		end
+                end
 
                 if expr
                     puts expr.call(Typelib.to_ruby(data))
-		elsif fields
+                elsif fields
                     values = field_operations.map do |_, field_ops|
                         display_fields(data, field_ops)
-		    end
-		    puts values.join(" ")
-		else
-		    data = display_fields(data, [])
+                    end
+                    puts values.join(" ")
+                else
+                    data = display_fields(data, [])
 
-		    if field_indexes
-			puts data.split(' ').values_at(*field_indexes).join(' ')
-		    else
-			puts data
-		    end
-		end
-	    end
-	end
+                    if field_indexes
+                        puts data.split(' ').values_at(*field_indexes).join(' ')
+                    else
+                        puts data
+                    end
+                end
+            end
+        end
     end
 
     class DisplayConfig < SampleModeConfig
-	def self.optname; "--show" end
-	Spec = DisplaySpec
+        def self.optname; "--show" end
+        Spec = DisplaySpec
         def show_metadata
             @show_metadata = true
         end
 
-	def execute
-	    if specs.empty?
-		return display_file_info
-	    elsif @show_type
-		specs.each do |s|
-		    stream = s.samples.stream
-		    pp stream.type
-		end
+        def execute
+            if specs.empty?
+                return display_file_info
+            elsif @show_type
+                specs.each do |s|
+                    stream = s.samples.stream
+                    pp stream.type
+                end
 
-	    else specs.each { |s| s.execute }
-	    end
-	end
+            else specs.each { |s| s.execute }
+            end
+        end
 
-	def type
-	    @show_type = true
-	end
+        def type
+            @show_type = true
+        end
 
-	def display_file_info
-	    mode = if logfiles.endian_swap ^ Pocolog.big_endian?
-			   "big endian"
-		   else
-			   "little endian"
-		   end
+        def display_file_info
+            mode = if logfiles.endian_swap ^ Pocolog.big_endian?
+                           "big endian"
+                   else
+                           "little endian"
+                   end
 
-	    puts "File data is in #{mode} byte order" 
-	    empty_streams = Hash.new
-	    info = Hash.new
+            puts "File data is in #{mode} byte order"
+            empty_streams = Hash.new
+            info = Hash.new
 
             streams = logfiles.streams
             if streams.empty?
@@ -412,76 +415,76 @@ module Pocolog
                 return
             end
 
-	    streams.each do |stream|
-		first_sample, last_sample = stream.interval_lg
-		count = stream.size
+            streams.each do |stream|
+                first_sample, last_sample = stream.interval_lg
+                count = stream.size
 
-		if count == 0
+                if count == 0
                     empty_streams[stream.name] = "#{stream.name} [#{stream.type.name}]\n"
                     if !stream.metadata.empty? && @show_metadata
                         stream.metadata.sort.each do |key, value|
                             empty_streams[stream.name] << "    #{key}: #{value}\n"
                         end
                     end
-		else
+                else
                     info[stream.name] = "#{stream.name} [#{stream.type.name}]\n"
                     if !stream.metadata.empty? && @show_metadata
                         stream.metadata.sort.each do |key, value|
                             info[stream.name] << "  #{key}: #{value}\n"
                         end
                     end
-		    info[stream.name] <<
-			"  #{count} samples"
+                    info[stream.name] <<
+                        "  #{count} samples"
 
-		    diff = last_sample - first_sample
-		    diff = Time.at(diff).to_hms if diff > 0
+                    diff = last_sample - first_sample
+                    diff = Time.at(diff).to_hms if diff > 0
                     first_sample = first_sample.strftime("%a %d/%m/%Y %H:%M:%S")
                     last_sample  = last_sample.strftime("%a %d/%m/%Y %H:%M:%S")
-		    info[stream.name] << " from #{first_sample} to #{last_sample} [#{diff}]"
-		end
-	    end
-	    info.keys.sort.each do |name|
-		puts "Stream #{info[name]}"
-	    end
-	    if !empty_streams.empty?
-		print "No samples for\n  "
-		puts empty_streams.values_at(*empty_streams.keys.sort).join("  ")
-	    end
-	end
+                    info[stream.name] << " from #{first_sample} to #{last_sample} [#{diff}]"
+                end
+            end
+            info.keys.sort.each do |name|
+                puts "Stream #{info[name]}"
+            end
+            if !empty_streams.empty?
+                print "No samples for\n  "
+                puts empty_streams.values_at(*empty_streams.keys.sort).join("  ")
+            end
+        end
     end
 
     class RegistryDisplay < ModeConfig
-	def self.optname; "--types" end
-	attr_reader :logfiles
+        def self.optname; "--types" end
+        attr_reader :logfiles
         def initialize(io, index_dir: nil)
             super
             @logfiles = Logfiles.new(*io, index_dir: index_dir)
         end
 
-	def execute
+        def execute
             registry = Typelib::Registry.new
-	    logfiles.streams.each do |stream|
+            logfiles.streams.each do |stream|
                 registry.merge stream.registry
-	    end
+            end
             registry.each do |type|
                 pp type
             end
-	end
+        end
     end
 
     class XMLRegistryDisplay < ModeConfig
-	def self.optname; "--types-xml" end
-	attr_reader :logfiles
+        def self.optname; "--types-xml" end
+        attr_reader :logfiles
         def initialize(io, index_dir: nil)
             super
             @logfiles   = Logfiles.new(*io, index_dir: index_dir)
         end
 
-	def execute
-	    logfiles.streams.each do |stream|
+        def execute
+            logfiles.streams.each do |stream|
                 puts stream.marshalled_registry
-	    end
-	end
+            end
+        end
     end
 
     class Config
@@ -515,7 +518,7 @@ module Pocolog
         def types
             self.mode = RegistryDisplay
         end
-	
+
         def types_xml
             self.mode = XMLRegistryDisplay
         end
@@ -523,52 +526,52 @@ module Pocolog
         def show_metadata
             @show_metadata = true
         end
-	
-	# Displays samples from +name+
-	def type(name)
-	    if mode_config
-		mode_config.type
-	    else
-		self.mode = TypeConfig
-		mode_config.typename(name)
-	    end
-	end
 
-	# Converts a file in an old format into the new format
-	def convert(file)
-	    self.mode = ToNewFormatConfig
-	    mode_config.output = file
-	end
+        # Displays samples from +name+
+        def type(name)
+            if mode_config
+                mode_config.type
+            else
+                self.mode = TypeConfig
+                mode_config.typename(name)
+            end
+        end
 
-	# Compresses the log file
-	def compress(file)
-	    self.mode = CompressConfig
-	    mode_config.output = file
-	end
+        # Converts a file in an old format into the new format
+        def convert(file)
+            self.mode = ToNewFormatConfig
+            mode_config.output = file
+        end
 
-	# Compresses the log file
-	def extract(file)
-	    self.mode = ExtractConfig
-	    mode_config.output = file
-	end
+        # Compresses the log file
+        def compress(file)
+            self.mode = CompressConfig
+            mode_config.output = file
+        end
 
-	# Adds a file to the file list
-	def input(file)
-	    if mode
-		raise ArgumentError, "cannot add files here"
-	    end
-	    @files << file
-	end
+        # Compresses the log file
+        def extract(file)
+            self.mode = ExtractConfig
+            mode_config.output = file
+        end
 
-	def method_missing(*args, &block) # :nodoc:
-	    if mode_config
-		mode_config.send(*args, &block)
-	    else super
-	    end
-	end
+        # Adds a file to the file list
+        def input(file)
+            if mode
+                raise ArgumentError, "cannot add files here"
+            end
+            @files << file
+        end
 
-	# Process the file according to the given mode and options
-	def execute
+        def method_missing(*args, &block) # :nodoc:
+            if mode_config
+                mode_config.send(*args, &block)
+            else super
+            end
+        end
+
+        # Process the file according to the given mode and options
+        def execute
             if mode_config
                 mode_config.execute
             else
@@ -578,7 +581,7 @@ module Pocolog
                 end
                 mode.execute
             end
-	end
+        end
     end
 
 end
@@ -600,11 +603,11 @@ parser = OptionParser.new do |opts|
     opts.separator ""
     opts.separator "Displays samples with"
     opts.separator "  pocolog FILE FILE --show STREAM [options]"
-    opts.on('--csv', String, "display stream data in a CSV-compatible format") do |name| 
+    opts.on('--csv', String, "display stream data in a CSV-compatible format") do |name|
         Pocolog.logger.level = Logger::FATAL
     end
-    opts.on('-s', '--show NAME', String, "display info/samples from the specified streams") do |name| 
-	config.show(name)
+    opts.on('-s', '--show NAME', String, "display info/samples from the specified streams") do |name|
+        config.show(name)
     end
     opts.on('--types', 'display the types registered in the file') do
         config.types
@@ -614,43 +617,43 @@ parser = OptionParser.new do |opts|
     end
 
     opts.on('--type [NAME]', String, 'display type definitions', 'pocolog --show NAME --type displays the stream type', 'pocolog --type NAME displays the definition of NAME') do |name|
-	config.type(name)
+        config.type(name)
     end
     opts.on('--rt', 'use real time as time reference') do
-	config.realtime
+        config.realtime
     end
     opts.on('-t', '--time', 'display time of samples') do
-	config.time = true
+        config.time = true
     end
     opts.on('-h', '--human', 'display time in a human-readable form') do
-	config.user_readable_time = true
+        config.user_readable_time = true
     end
     opts.on('--expr=EXPR', String, "a Ruby expression to evaluate for each sample. In the code, 'sample' refers to the current stream value") do |spec|
         config.eval_expr(spec)
     end
-    opts.on('--at SPEC', String, 'config only specified sample, see below for definition of SPEC') do |spec| 
-	config.at(time_from_spec(spec))
+    opts.on('--at SPEC', String, 'config only specified sample, see below for definition of SPEC') do |spec|
+        config.at(time_from_spec(spec))
     end
-    opts.on('--from SPEC', String, 'begin at the specified sample, see below for definition of SPEC') do |spec| 
-	config.from(time_from_spec(spec))
+    opts.on('--from SPEC', String, 'begin at the specified sample, see below for definition of SPEC') do |spec|
+        config.from(time_from_spec(spec))
     end
     opts.on('--to SPEC', String, 'stop at the specified sample, see below for definition of SPEC') do |spec|
-	config.to(time_from_spec(spec))
+        config.to(time_from_spec(spec))
     end
-    opts.on('--every SPEC', String, 'skip the specified amount of samples or time between two displayed samples', 'see below for definition of SPEC') do |spec| 
-	config.every(time_from_spec(spec))
+    opts.on('--every SPEC', String, 'skip the specified amount of samples or time between two displayed samples', 'see below for definition of SPEC') do |spec|
+        config.every(time_from_spec(spec))
     end
     opts.on('--fields x,y,z', Array, 'selects a comma-separated set of fields') do |fields|
-	config.fields = fields
+        config.fields = fields
     end
     opts.on('--filter REGEX', String, 'select the fields whose name matches REGEX') do |filter|
-	config.filter = Regexp.new(filter)
+        config.filter = Regexp.new(filter)
     end
     opts.on('--filter-out REGEX', String, 'remove the fields whose name matches REGEX') do |filter_out|
-	config.filter_out = Regexp.new(filter_out)
+        config.filter_out = Regexp.new(filter_out)
     end
     opts.on('--remove-prefix STRING', String, 'remove the prefix PREFIX from the front of field names') do |remove_prefix|
-	config.remove_prefix = Regexp.new("^#{Regexp.quote(remove_prefix)}")
+        config.remove_prefix = Regexp.new("^#{Regexp.quote(remove_prefix)}")
     end
     opts.separator ""
     opts.separator "  For --at, --from and --to, either a sample index or a time can be specified"
@@ -660,13 +663,13 @@ parser = OptionParser.new do |opts|
     opts.separator ""
     opts.separator 'File convertion:'
     opts.on('--compress [OUTPUT]', 'compresses the log files into OUTPUT') do |output|
-	config.compress(output || config.io.first.path)
+        config.compress(output || config.io.first.path)
     end
     opts.on('--to-new-format OUTPUT', 'converts the source file into the new format in OUTPUT') do |output|
-	config.convert(output)
+        config.convert(output)
     end
     opts.on('--extract [OUTPUT]', "creates a new log file with only the streams specified", "by the following --stream options") do |output|
-	config.extract(output || config.io.first.path)
+        config.extract(output || config.io.first.path)
     end
     opts.on("--streams NAME[:start_index[:end_index]]", Array, 'specifies the stream names for --extract') do |names|
         names.each do |n|
@@ -677,18 +680,18 @@ parser = OptionParser.new do |opts|
         end
     end
     opts.on('--little-endian', 'the source file of --to-new-format is little-endian', 'Needed by --to-new-format to convert v1 files') do
-	config.little_endian
+        config.little_endian
     end
     opts.on('--big-endian', 'the source file of --to-new-format is big-endian', 'Needed by --to-new-format to convert v1 files') do
-	config.big_endian
+        config.big_endian
     end
 
     opts.separator ""
     opts.separator "Common options"
-    opts.on("--help", "this help") do 
-	puts opts
-	puts
-	exit
+    opts.on("--help", "this help") do
+        puts opts
+        puts
+        exit
     end
 end
 

--- a/lib/pocolog/data_stream.rb
+++ b/lib/pocolog/data_stream.rb
@@ -294,14 +294,13 @@ module Pocolog
             marshalled_data = logfile.read_one_data_payload(block_pos)
             data = sample || type.new
             data.from_buffer_direct(marshalled_data)
-            if logfile.endian_swap
-                data = data.endian_swap
-            end
+            data = data.endian_swap if logfile.endian_swap
             data
         rescue Interrupt
             raise
-        rescue Exception => e
-            raise e, "failed to unmarshal sample in block at position #{block_pos}: #{e.message}", e.backtrace
+        rescue StandardError => e
+            raise e, "failed to unmarshal sample in block at position #{block_pos}: "\
+                     "#{e.message}", e.backtrace
         end
 
         def data(data_header = nil)

--- a/lib/pocolog/file_index_builder.rb
+++ b/lib/pocolog/file_index_builder.rb
@@ -57,6 +57,7 @@ module Pocolog
             index_map = stream_info.index_map
             interval_rt = []
             base_time = nil
+
             # Read the realtime of the first and last samples
             unless index_map.empty?
                 block_stream.seek(index_map.first)
@@ -69,12 +70,11 @@ module Pocolog
                 interval_rt = [first_block.rt_time, last_block.rt_time]
 
                 base_time = index_map[1]
-                sample_index = -1
-                index_map = index_map.each_slice(2).map do |block_pos, lg_time|
-                    sample_index += 1
-                    [block_pos, lg_time - base_time, sample_index]
+                index_map = StreamIndex.map_entries_internal(index_map) do |pos, time|
+                    [pos, time - base_time]
                 end
             end
+
             StreamInfo.from_raw_data(
                 stream_info.stream_block_pos,
                 interval_rt, base_time, index_map

--- a/lib/pocolog/format/v2.rb
+++ b/lib/pocolog/format/v2.rb
@@ -4,7 +4,7 @@ module Pocolog
     module Format
         module V2
             # The magic code present at the beginning of each pocolog file
-            MAGIC = 'POCOSIM'
+            MAGIC = "POCOSIM"
             # Format version ID. Increment this when the file format changes in a
             # non-backward-compatible way
             VERSION = 2
@@ -12,7 +12,7 @@ module Pocolog
             PROLOGUE_SIZE = MAGIC.size + 9
 
             # The magic code at the beginning of a pocolog index
-            INDEX_MAGIC = 'POCOSIM_INDEX'
+            INDEX_MAGIC = "POCOSIM_INDEX"
             # The current index version. Unlike with the format version, a
             # changing index version will only cause rebuilding the index
             #
@@ -177,7 +177,7 @@ module Pocolog
                     index_io.seek(info.index_pos)
                     index_data = index_io.read(index_size)
                     if index_data.size != index_size
-                        raise InvalidIndex, 'not enough or too much data in index'
+                        raise InvalidIndex, "not enough or too much data in index"
                     end
 
                     index_data = index_data.unpack("Q>*")
@@ -248,7 +248,9 @@ module Pocolog
 
                 streams = []
                 stream_count.times do
-                    values = index_io.read(INDEX_STREAM_DESCRIPTION_SIZE).unpack('Q>*')
+                    values =
+                        index_io.read(INDEX_STREAM_DESCRIPTION_SIZE)
+                                .unpack("Q>*")
                     # This is (declaration_pos, index_pos, stream_size)
                     declaration_pos, index_pos, base_time, stream_size,
                         interval_rt_min, interval_rt_max,
@@ -327,12 +329,12 @@ module Pocolog
             #   should be stored
             def self.write_index(index_io, file_io, streams, version: INDEX_VERSION)
                 if index_io.path == file_io.path
-                    raise ArgumentError, 'attempting to overwrite the file by its index'
+                    raise ArgumentError, "attempting to overwrite the file by its index"
                 end
 
                 write_index_prologue(index_io, file_io.stat.size, file_io.stat.mtime,
                                      version: version)
-                index_io.write([streams.size].pack('Q>'))
+                index_io.write([streams.size].pack("Q>"))
 
                 index_list_pos = index_io.tell
                 index_data_pos = INDEX_STREAM_DESCRIPTION_SIZE * streams.size +
@@ -343,9 +345,9 @@ module Pocolog
                         index_contents_from_stream(stream_info, index_data_pos)
 
                     index_io.seek(index_list_pos)
-                    index_io.write(index_stream_info.pack('Q>*'))
+                    index_io.write(index_stream_info.pack("Q>*"))
                     index_io.seek(index_data_pos)
-                    index_io.write(index_data.pack('Q>*'))
+                    index_io.write(index_data.pack("Q>*"))
 
                     index_list_pos += INDEX_STREAM_DESCRIPTION_SIZE
                     index_data_pos += index_data.size * 8

--- a/lib/pocolog/format/v2.rb
+++ b/lib/pocolog/format/v2.rb
@@ -23,7 +23,7 @@ module Pocolog
             # Size of a stream description in the index
             INDEX_STREAM_DESCRIPTION_SIZE = 8 * 8
             # Size of an entry in the index table
-            INDEX_STREAM_ENTRY_SIZE = 8 * 3
+            INDEX_STREAM_ENTRY_SIZE = 8 * 2
 
             # The size of the generic block header
             BLOCK_HEADER_SIZE = 8
@@ -180,8 +180,7 @@ module Pocolog
                         raise InvalidIndex, 'not enough or too much data in index'
                     end
 
-                    index_data = index_data.unpack('Q>*')
-                                           .each_slice(3).to_a
+                    index_data = index_data.unpack("Q>*")
                     StreamInfo.from_raw_data(
                         info.declaration_pos, info.interval_rt, info.base_time,
                         index_data
@@ -369,7 +368,7 @@ module Pocolog
                     interval_lg[0] || 0, interval_lg[1] || 0
                 ]
 
-                [index_stream_info, stream_info.index.index_map.flatten]
+                [index_stream_info, stream_info.index.index_map]
             end
         end
     end

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -128,9 +128,8 @@ module Pocolog
             if base_time
                 all_streams.each_with_index do |stream, i|
                     stream.stream_index.base_time = base_time
-                    for entry in stream.stream_index.index_map
-                        sort_index << entry[1] * size + i
-                    end
+                    times = stream.stream_index.raw_each_time.map { |t| t * size + i }
+                    sort_index.concat(times)
                 end
             end
 

--- a/lib/pocolog/stream_aligner.rb
+++ b/lib/pocolog/stream_aligner.rb
@@ -119,11 +119,11 @@ module Pocolog
             Pocolog.info "adding #{streams.size} streams with #{streams_size} samples"
 
             tic = Time.now
-            if !base_time
+            unless base_time
                 @base_time = streams.map { |s| s.stream_index.base_time }.compact.min
             end
 
-            sort_index = Array.new
+            sort_index = []
             all_streams = (@streams + streams)
             if base_time
                 all_streams.each_with_index do |stream, i|

--- a/lib/pocolog/stream_index.rb
+++ b/lib/pocolog/stream_index.rb
@@ -9,31 +9,32 @@ module Pocolog
     # {IOSequence} object. This is transparent to the index as {IOSequence}
     # provides an interface where positions span the IOs
     class StreamIndex
+        # Time (in microseconds) used to reference all the other times in the index
+        #
+        # @return [Integer]
         attr_reader :base_time
 
         # The index information
         #
-        # This is an array of tuples.
-        #
-        # REALLY IMPORTANT: the tuples MUST be of size 3 or lower. On CRuby,
-        # this ensures that the elements are stored within the array object
-        # itself instead of allocating extra memory on the heap.
+        # This is an flat array of file_pos, time for each sample
         attr_reader :index_map
 
         # Initialize a stream index object from the raw information
         def self.from_raw_data(base_time, index_map)
-            index = StreamIndex.new(base_time: base_time)
-            index.index_map.concat(index_map)
-            index
+            raise if index_map.first.kind_of?(Array)
+
+            StreamIndex.new(base_time: base_time, index_map: index_map)
         end
 
-        def initialize(base_time: nil)
+        def initialize(base_time: nil, index_map: [])
+            raise if index_map.first.kind_of?(Array)
+
             @base_time = base_time
-            @index_map = []
+            @index_map = index_map
         end
 
         def initialize_copy(_copy)
-            raise NotImplementedError, 'StreamInfo is non-copyable'
+            raise NotImplementedError, "StreamInfo is non-copyable"
         end
 
         # Change this stream's base time
@@ -47,15 +48,46 @@ module Pocolog
             offset = @base_time - value
             return if offset == 0
 
-            @index_map = index_map.map do |file_pos, time, sample_index|
-                [file_pos, time + offset, sample_index]
-            end
+            @index_map = map_entries_internal { |pos, t| [pos, t + offset] }
             @base_time = value
         end
 
+        # Create a new index object with its entries changed
+        #
+        # @yieldparam [Integer] pos the file position for this sample
+        # @yieldparam [Integer] time the internal sample time, as an offset in
+        #   microseconds from {#base_time}
+        def map_entries(&block)
+            new_map = map_entries_internal(&block)
+            self.class.from_raw_data(@base_time, new_map)
+        end
+
+        # @api private
+        #
+        # Non-destructively change the internal @index_map object
+        def map_entries_internal(&block)
+            self.class.map_entries_internal(@index_map, &block)
+        end
+
+        # @api private
+        #
+        # Map entries of an index index map data array
+        #
+        # @yieldparam [Integer] pos file position
+        # @yieldparam [Integer] time internal time
+        # @yieldreturn [(Integer, Integer)] new position and time
+        # @return [Array] updated index map
+        def self.map_entries_internal(index_map)
+            new_map = Array.new(index_map.size)
+            (0...index_map.size).step(2) do |i|
+                new_map[i, 2] = yield(index_map[i, 2])
+            end
+            new_map
+        end
+
         # Number of samples in this index
-        def size
-            @index_map.size
+        def sample_count
+            @index_map.size / 2
         end
 
         # True if there are no samples indexed in self
@@ -67,9 +99,18 @@ module Pocolog
         #
         # @yieldparam [Integer] file_pos the position in the file
         # @yieldparam [Integer] time the time since {#base_time}
-        def raw_each
-            @index_map.each do |file_pos, time, _|
-                yield(file_pos, time)
+        def raw_each(&block)
+            @index_map.each_slice(2, &block)
+        end
+
+        # Iterate over the sample times
+        #
+        # @yieldparam [Integer] time the time since {#base_time} in microseconds
+        def raw_each_time
+            return enum_for(__method__) unless block_given?
+
+            (1...@index_map.size).step(2) do |i|
+                yield(@index_map[i])
             end
         end
 
@@ -81,64 +122,67 @@ module Pocolog
         #   backed by a {IOSequence}.
         def concat(stream_index, file_pos_offset = 0)
             @base_time ||= stream_index.base_time
+            time_offset = stream_index.base_time - base_time
 
-            time_offset         = stream_index.base_time - base_time
-            sample_index_offset = size
-            stream_index.index_map.each do |file_pos, time, sample_index|
-                index_map << [file_pos + file_pos_offset,
-                              time + time_offset,
-                              sample_index + sample_index_offset]
+            new_index_map = stream_index.map_entries_internal do |pos, time|
+                [pos + file_pos_offset, time + time_offset]
             end
+            @index_map.concat(new_index_map)
         end
 
         # Append a new sample to the index
-        def add_sample(pos, time)
-            add_raw_sample(pos, time)
+        #
+        # @param [Integer] internal_time time as an offset in microseconds from the
+        #   base time
+        def add_sample(pos, internal_time)
+            add_raw_sample(pos, internal_time)
         end
 
         # Append a new sample to the index
-        def add_raw_sample(pos, time)
-            @base_time ||= time
-            @index_map << [pos, time - @base_time, @index_map.size]
+        #
+        # @param [Integer] internal_time time as an offset in microseconds from the
+        #   base time
+        def add_raw_sample(pos, internal_time)
+            @base_time ||= internal_time
+            @index_map << pos << (internal_time - @base_time)
         end
 
         # Return a new index without any sample before the given time
         #
+        # @param [Time] time
         # @return [StreamIndex]
         def remove_before(time)
             index = sample_number_by_time(time)
-            index_map = (index...size).map do |i|
-                e = @index_map[i].dup
-                e[2] = i - index
-                e
-            end
-            self.class.from_raw_data(@base_time, index_map)
+            new_map = @index_map[(index * 2)...@index_map.size]
+            self.class.from_raw_data(@base_time, new_map)
         end
 
-        # Return a new index without any sample after the given time
+        # Return a new index without any sample at or after the given time
         #
+        # @param [Time] time
         # @return [StreamIndex]
         def remove_after(time)
             index = sample_number_by_time(time)
-            self.class.from_raw_data(@base_time, @index_map[0...index])
+            new_map = @index_map[0...(index * 2)]
+            self.class.from_raw_data(@base_time, new_map)
         end
 
         # Return the index with only every N-th samples
         def resample_by_index(period)
-            self.class.from_raw_data(@base_time, @index_map) if period == 1
+            return self.class.from_raw_data(@base_time, @index_map) if period == 1
 
-            new_map = Array.new((size + period - 1) / period)
-            new_map.size.times do |i|
-                entry = @index_map[i * period].dup
-                entry[2] = i
-                new_map[i] = entry
+            new_map = Array.new((sample_count + period - 1) / period * 2)
+            (0...new_map.size).step(2) do |i|
+                j = i * period
+                new_map[i] = @index_map[j]
+                new_map[i + 1] = @index_map[j + 1]
             end
             self.class.from_raw_data(@base_time, new_map)
         end
 
         # Return the index with only every N-th samples
         def resample_by_time(period, start_time: nil)
-            period_us = period * 1_000_000
+            period_us = Integer(period * 1_000_000)
             next_time =
                 if start_time
                     self.class.time_to_internal(start_time, @base_time)
@@ -147,13 +191,13 @@ module Pocolog
                 end
 
             new_map = []
-            @index_map.each do |entry|
-                entry_t = entry[1]
-                if entry_t >= next_time
-                    new_map << [entry[0], entry[1], new_map.size]
-                    next_time += period_us until entry_t < next_time
+            raw_each do |pos, time|
+                if time >= next_time
+                    new_map << pos << time
+                    next_time += ((time - next_time) / period_us + 1) * period_us
                 end
             end
+
             self.class.from_raw_data(@base_time, new_map)
         end
 
@@ -197,8 +241,10 @@ module Pocolog
         #
         # @param [Integer]
         def sample_number_by_internal_time(sample_time)
-            _pos_, _time, idx = @index_map.bsearch { |_, t, _| t >= sample_time }
-            idx || size
+            idx = (0...sample_count).bsearch do |i|
+                @index_map[i * 2 + 1] >= sample_time
+            end
+            idx || sample_count
         end
 
         # Returns the IO position of a sample
@@ -207,7 +253,7 @@ module Pocolog
         # @return [Integer] the sample's position in the backing IO
         # @raise IndexError if the sample number is out of bounds
         def file_position_by_sample_number(sample_number)
-            @index_map.fetch(sample_number)[0]
+            @index_map.fetch(sample_number * 2)
         end
 
         # Returns the time of a sample
@@ -216,7 +262,7 @@ module Pocolog
         # @return [Integer] the sample's time in the index' internal encoding
         # @raise IndexError if the sample number is out of bounds
         def internal_time_by_sample_number(sample_number)
-            @index_map.fetch(sample_number)[1]
+            @index_map.fetch(sample_number * 2 + 1)
         end
 
         # Returns the time of a sample

--- a/lib/pocolog/stream_info.rb
+++ b/lib/pocolog/stream_info.rb
@@ -23,7 +23,9 @@ module Pocolog
         attr_reader :index
 
         # True if this stream is empty
-        def empty?; size == 0 end
+        def empty?
+            size == 0
+        end
 
         # Initialize a stream info object from raw information
         def self.from_raw_data(declaration_block, interval_rt, base_time, index_map)
@@ -105,15 +107,15 @@ module Pocolog
             @declaration_blocks = [declaration_block]
             @index = StreamIndex.from_raw_data(base_time, index_map)
             @interval_rt = interval_rt
-            @size = index.size
-            if !index.empty?
-                @interval_io =
-                    [index.file_position_by_sample_number(0),
-                     index.file_position_by_sample_number(-1)]
-                @interval_lg =
-                    [index.internal_time_by_sample_number(0) + index.base_time,
-                     index.internal_time_by_sample_number(-1) + index.base_time]
-            end
+            @size = index.sample_count
+            return if index.empty?
+
+            @interval_io =
+                [index.file_position_by_sample_number(0),
+                 index.file_position_by_sample_number(-1)]
+            @interval_lg =
+                [index.internal_time_by_sample_number(0) + index.base_time,
+                 index.internal_time_by_sample_number(-1) + index.base_time]
         end
     end
 end

--- a/test/stream_index_test.rb
+++ b/test/stream_index_test.rb
@@ -25,11 +25,11 @@ module Pocolog
             end
         end
 
-        describe "#size" do
+        describe "#sample_count" do
             it "returns the number of samples in the index" do
-                assert_equal 0, stream_index.size
+                assert_equal 0, stream_index.sample_count
                 stream_index.add_sample(0, 10)
-                assert_equal 1, stream_index.size
+                assert_equal 1, stream_index.sample_count
             end
         end
 
@@ -104,7 +104,7 @@ module Pocolog
             end
             it "adds the new index' entries to the existing" do
                 stream_index.concat(new_index)
-                assert_equal 5, stream_index.size
+                assert_equal 5, stream_index.sample_count
                 assert_equal 3, stream_index.file_position_by_sample_number(3)
                 assert_equal Time.at(0, base_time + 4), stream_index.time_by_sample_number(3)
             end


### PR DESCRIPTION
It was an array of 3-tuples, which means we were paying a full object (64 bytes + associated GC costs) for each single samples. Normalizing decent logs (i.e. 24h or more) in syskit-log would halt to a crawl.

In addition to requiring a flatten to write indexes, and a processing when loading.