### PR TITLE
fix: allow passing the streams' interval_rt explicitly to create_index_from_raw_info

### DIFF
--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -33,6 +33,8 @@ module Pocolog
         end
 
         # Create a BlockStream object that acts on a given file
+        #
+        # @return [BlockStream]
         def self.open(path)
             if block_given?
                 File.open(path) do |io|
@@ -167,6 +169,7 @@ module Pocolog
             io.read(BLOCK_HEADER_SIZE)
         end
 
+        # @return [BlockHeader]
         def self.read_block_header(io, pos = nil)
             BlockHeader.parse(read_block_header_raw(io, pos))
         end
@@ -188,6 +191,8 @@ module Pocolog
         end
 
         # Read the header of the next block
+        #
+        # @return [BlockHeader,nil]
         def read_next_block_header
             skip(@payload_size) if @payload_size != 0
 

--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -137,6 +137,16 @@ module Pocolog
         # Raises MissingPrologue if no prologue is found, or ObsoleteVersion if
         # the file format is not up-to-date (in which case one has to run
         # pocolog --to-new-format).
+        def read_prologue_raw # :nodoc:
+            Format::Current.read_prologue_raw(io)
+        end
+
+        # If the IO is a file, it starts with a prologue to describe the file
+        # format
+        #
+        # Raises MissingPrologue if no prologue is found, or ObsoleteVersion if
+        # the file format is not up-to-date (in which case one has to run
+        # pocolog --to-new-format).
         def read_prologue # :nodoc:
             big_endian = Format::Current.read_prologue(io)
             @format_version = Format::Current::VERSION
@@ -152,17 +162,21 @@ module Pocolog
             end
         end
 
-        def self.read_block_header(io, pos = nil)
+        def self.read_block_header_raw(io, pos = nil)
             io.seek(pos, IO::SEEK_SET) if pos
-            BlockHeader.parse(io.read(BLOCK_HEADER_SIZE))
+            io.read(BLOCK_HEADER_SIZE)
         end
 
-        # Read the header of the next block
-        def read_next_block_header
-            skip(@payload_size) if @payload_size != 0
+        def self.read_block_header(io, pos = nil)
+            BlockHeader.parse(read_block_header_raw(io, pos))
+        end
 
-            header = read(BLOCK_HEADER_SIZE)
-            return unless header
+        # Read the bytes from the block header at the current position
+        #
+        # Unlike {#read_next_block_header}, it does not skip remaining payload
+        # bytes, and does not prepare the stream to
+        def read_block_header_raw
+            return unless (header = read(BLOCK_HEADER_SIZE))
 
             if header.size != BLOCK_HEADER_SIZE
                 raise NotEnoughData,
@@ -170,9 +184,34 @@ module Pocolog
                       "expected #{BLOCK_HEADER_SIZE})"
             end
 
+            header
+        end
+
+        # Read the header of the next block
+        def read_next_block_header
+            skip(@payload_size) if @payload_size != 0
+
+            return unless (header = read_block_header_raw)
+
             block = BlockHeader.parse(header)
             @payload_size = block.payload_size
             block
+        end
+
+        # Read the bytes from the block at the current position
+        #
+        # @return [(BlockHeader, String, String)]
+        def read_block_raw
+            header_raw = read_block_header_raw
+            header = BlockHeader.parse(header_raw)
+            payload = read(header.payload_size)
+            if !payload || payload.size != header.payload_size
+                raise NotEnoughData,
+                      "expected to read #{header.payload_size} payload bytes but got "\
+                      "#{payload ? payload.size : 'EOF'}"
+            end
+
+            [header, header_raw, payload]
         end
 
         # Information about a stream declaration block

--- a/lib/pocolog/format/v2.rb
+++ b/lib/pocolog/format/v2.rb
@@ -43,6 +43,19 @@ module Pocolog
             # have a min
             STREAM_BLOCK_DECLARATION_HEADER_SIZE_MIN = 9
 
+            # Read the raw bytes from the prologue and return them
+            #
+            # @return [String]
+            # @raise MissingPrologue
+            def self.read_prologue_raw(io)
+                header = io.read(PROLOGUE_SIZE)
+                if !header || (header.size < PROLOGUE_SIZE)
+                    raise MissingPrologue, "#{io.path} too small"
+                end
+
+                header
+            end
+
             # Read a file's prologue
             #
             # @param [IO] io the file from which to read the prologue
@@ -51,11 +64,7 @@ module Pocolog
             # @return [(Integer,Boolean)] the file format version and a flag that
             #   tells whether the file's data is encoded as big or little endian
             def self.read_prologue(io, validate_version: true)
-                header = io.read(PROLOGUE_SIZE) || ''
-                if !header || (header.size < PROLOGUE_SIZE)
-                    raise MissingPrologue, "#{io.path} too small"
-                end
-
+                header = read_prologue_raw(io)
                 magic = header[0, MAGIC.size]
                 if magic != MAGIC
                     raise MissingPrologue,


### PR DESCRIPTION
This avoids having to re-read it from the log stream. The need arises
with compressed files, as we would have to seek the whole file (!) to
do something that's essentially already done during index creation.