### PR TITLE
chore: cleanup index-related methods

### DIFF
--- a/lib/pocolog/format/v2.rb
+++ b/lib/pocolog/format/v2.rb
@@ -211,10 +211,10 @@ module Pocolog
             # reading any actual data (no index data and no stream data)
             #
             # @return [Array<(BlockStream::StreamBlock,IndexStreamInfo)>]
-            def self.read_minimal_info(index_io, file_io)
+            def self.read_minimal_info(index_io, file_io, validate: true)
                 index_stream_info = read_index_minimal_info(
                     index_io,
-                    expected_file_size: file_io.size
+                    expected_file_size: (file_io.size if validate)
                 )
 
                 index_stream_info.map do |info|

--- a/test/format_test.rb
+++ b/test/format_test.rb
@@ -55,23 +55,15 @@ module Pocolog
             end
 
             describe "#read_index" do
-                it "raises InvalidIndex if the file is smaller than the expected file size" do
+                it "raises InvalidIndex if trying to read the index from a truncated file" do
                     index_real_size = index_io.size
-                    flexmock(index_io).should_receive(:size).and_return(index_real_size - 1)
+                    index_io.close
+                    File.truncate(logfile_path("test.0.idx"), index_real_size - 1)
+                    index_io = File.open(logfile_path("test.0.idx"))
                     e = assert_raises(InvalidIndex) do
                         Format::Current.read_index(index_io)
                     end
-                    assert_equal "index file should be of size #{index_real_size} "\
-                                 "but is of size #{index_io.size}", e.message
-                end
-                it "raises InvalidIndex if the file is bigger than the expected file size" do
-                    index_real_size = index_io.size
-                    flexmock(index_io).should_receive(:size).and_return(index_real_size + 1)
-                    e = assert_raises(InvalidIndex) do
-                        Format::Current.read_index(index_io)
-                    end
-                    assert_equal "index file should be of size #{index_real_size} but "\
-                                 "is of size #{index_io.size}", e.message
+                    assert_equal "index file seem truncated", e.message
                 end
             end
         end

--- a/test/format_test.rb
+++ b/test/format_test.rb
@@ -21,7 +21,7 @@ module Pocolog
             end
 
             it "saves the stream info" do
-                info = Format::Current.read_index_stream_info(index_io)
+                info = Format::Current.read_index_minimal_info(index_io)
                 assert_equal 1, info.size
 
                 stream_info = info.first


### PR DESCRIPTION
On top of #34 

This is preparatory work for the compressed datasets in syskit-log

The main feature change is that index reading methods do not assume that the IO is seekable anymore. Mainly,
it means not doing pre-validation checks on size, but checking on whether we reached EOF while reading.

Additionally, the index read/write method names are now mapped 1:1, i.e. every time there is a read method
doing a step of the read, there is going to be a write method with the equivalent name that takes care of the
same part.