### PR TITLE
feat: re-implement a read API oriented towards sequential reading of files

### DIFF
--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -236,7 +236,7 @@ module Pocolog
             end
 
             def self.read_string(raw_data, offset)
-                size = read(raw_data, offset, 4).unpack('V').first
+                size = read(raw_data, offset, 4).unpack1("V")
                 [read(raw_data, offset + 4, size), (offset + 4 + size)]
             end
 
@@ -420,7 +420,7 @@ module Pocolog
         def read_data_block(uncompress: true)
             raw_header = read_payload(Format::Current::DATA_BLOCK_HEADER_SIZE)
             raw_data   = read_payload
-            compressed = raw_header[-1, 1].unpack('C').first
+            compressed = raw_header[-1, 1].unpack1("C")
             if uncompress && (compressed != 0)
                 # Payload is compressed
                 raw_data = Zlib::Inflate.inflate(raw_data)
@@ -434,7 +434,7 @@ module Pocolog
         # after read_next_block_header)
         def read_data_block_payload
             skip(Format::Current::DATA_BLOCK_HEADER_SIZE - 1)
-            compressed = read_payload(1).unpack('C').first
+            compressed = read_payload(1).unpack1("C")
             data = read_payload
             if compressed != 0
                 # Payload is compressed

--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -100,7 +100,9 @@ module Pocolog
 
         # Move to the beginning of the stream
         def rewind
-            seek(0)
+            io.rewind
+            @buffer_io = StringIO.new
+            @payload_size = 0
         end
 
         # Seek to the current raw position in the IO

--- a/lib/pocolog/format.rb
+++ b/lib/pocolog/format.rb
@@ -13,13 +13,13 @@ module Pocolog
 
     # true if this machine is big endian
     def self.big_endian?
-        "LAAS".unpack('L').pack('N') == "LAAS"
+        "LAAS".unpack("L").pack("N") == "LAAS"
     end
 
     STREAM_BLOCK           = 1
     DATA_BLOCK             = 2
     CONTROL_BLOCK          = 3
-    BLOCK_TYPES            = [STREAM_BLOCK, DATA_BLOCK, CONTROL_BLOCK]
+    BLOCK_TYPES            = [STREAM_BLOCK, DATA_BLOCK, CONTROL_BLOCK].freeze
 
     DATA_STREAM            = 1
 

--- a/lib/pocolog/io_sequence.rb
+++ b/lib/pocolog/io_sequence.rb
@@ -54,7 +54,7 @@ module Pocolog
         def eof?
             (@current_io == ios.last) && @current_io.eof?
         end
-        
+
         def open
             @io = io.map do |file|
                 if file.closed?
@@ -97,7 +97,7 @@ module Pocolog
                 buffer
             end
         end
-        
+
         # @api private
         #
         # Selects the IO that can provide the given position, and sets the

--- a/lib/pocolog/io_sequence.rb
+++ b/lib/pocolog/io_sequence.rb
@@ -66,6 +66,8 @@ module Pocolog
 
         # Seek to the beginning of the file
         def rewind
+            return if ios.empty?
+
             select_io_from_pos(0)
         end
 

--- a/lib/pocolog/logfiles.rb
+++ b/lib/pocolog/logfiles.rb
@@ -113,9 +113,8 @@ module Pocolog
             @data = nil
             @streams = nil
             @compress = false
-            @data_header_buffer = ''
             @streams =
-                if write_only
+                if write_only || io.empty?
                     []
                 else
                     load_stream_info(io, index_dir: index_dir, silent: silent)
@@ -178,7 +177,7 @@ module Pocolog
         # files are named
         def new_file(filename = nil)
             name = filename || "#{basename}.#{num_io}.log"
-            io = File.new(name, 'w+')
+            io = File.new(name, "w+")
             Format::Current.write_prologue(io)
             streams.each_with_index do |s, i|
                 Logfiles.write_stream_declaration(

--- a/lib/pocolog/logfiles.rb
+++ b/lib/pocolog/logfiles.rb
@@ -545,12 +545,12 @@ module Pocolog
             matches = streams_from_type(type)
             if matches.empty?
                 raise ArgumentError,
-                      'there is no stream in this file with the required type'
+                      "there is no stream in this file with the required type"
             elsif matches.size > 1
                 raise ArgumentError,
-                      'there is more than one stream in this file with the required type'
+                      "there is more than one stream in this file with the required type"
             else
-                return matches.first
+                matches.first
             end
         end
 

--- a/test/logfiles_test.rb
+++ b/test/logfiles_test.rb
@@ -84,6 +84,13 @@ module Pocolog
                     assert_run_successful(logfile_path('test.0.log'), "-s", "s#{stream_i}")
                 end
             end
+            it "creates an empty file via #new_file after the Logfiles creation" do
+                logfile = Logfiles.new
+                path = logfile_path("new_file.0.log")
+                logfile.new_file(path.to_s)
+                logfile.close
+                Logfiles.open(path.to_s)
+            end
         end
 
         describe "#each_block_header" do

--- a/test/logfiles_test.rb
+++ b/test/logfiles_test.rb
@@ -4,9 +4,9 @@ module Pocolog
     describe Logfiles do
         attr_reader :stream_all_samples
         before do
-            @stream_all_samples = Array.new
-            create_logfile 'test.0.log' do
-                create_logfile_stream 'all'
+            @stream_all_samples = []
+            create_logfile "test.0.log" do
+                create_logfile_stream "all"
                 100.times do |i|
                     stream_all_samples << [Time.at(i), Time.at(i * 100), i]
                     write_logfile_sample Time.at(i), Time.at(i * 100), i


### PR DESCRIPTION
There is the use of it and the current seek-heavy API really is not
efficient when doing so. It was the original way pocolog files were
meant to be used, until we went all-in on the index-based DataStream
API.