### PR TITLE
fix: make remove_after remove indexes strictly after the given time

### DIFF
--- a/lib/pocolog/stream_index.rb
+++ b/lib/pocolog/stream_index.rb
@@ -157,12 +157,14 @@ module Pocolog
             self.class.from_raw_data(@base_time, new_map)
         end
 
-        # Return a new index without any sample at or after the given time
+        # Return a new index without any sample after the given time
         #
         # @param [Time] time
         # @return [StreamIndex]
         def remove_after(time)
-            index = sample_number_by_time(time)
+            sample_time = StreamIndex.time_to_internal(time, base_time)
+            index = sample_number_by_internal_time(sample_time)
+            index += 1 if @index_map[index * 2 + 1] == sample_time
             new_map = @index_map[0...(index * 2)]
             self.class.from_raw_data(@base_time, new_map)
         end

--- a/test/data_stream_test.rb
+++ b/test/data_stream_test.rb
@@ -525,6 +525,7 @@ module Pocolog
                 stream = @stream.from_logical_time(base_time + 10.1)
                 assert_equal [base_time + 1, base_time + 11, 1],
                              stream.seek(base_time + 11)
+                assert_equal base_time + 11, stream.stream_index.start_time
             end
         end
 
@@ -548,16 +549,17 @@ module Pocolog
                               [base_time + 1, base_time + 11, 1]], stream.each.to_a
             end
 
-            it "removes a sample whose time strictly equals the given time" do
-                stream = @stream.to_logical_time(base_time + 12)
+            it "keeps a sample whose time strictly equals the given time" do
+                stream = @stream.to_logical_time(base_time + 11)
                 assert_equal [[base_time + 0, base_time + 10, 0],
                               [base_time + 1, base_time + 11, 1]], stream.each.to_a
             end
 
             it "updates the stream index of the returned stream" do
-                stream = @stream.to_logical_time(base_time + 12)
+                stream = @stream.to_logical_time(base_time + 11)
                 assert_equal [base_time + 1, base_time + 11, 1],
                              stream.seek(base_time + 11)
+                assert_equal base_time + 11, stream.stream_index.end_time
             end
         end
 


### PR DESCRIPTION
It was after-or-equal, which actually goes against the documentation (and intent) of to_logical_time.

One inconsistency right now is that to_logical_time(lg_interval[1]) does remove the last sample.