### PR TITLE
fix: catch all errors but interrupt on repair

### DIFF
--- a/lib/pocolog/repair.rb
+++ b/lib/pocolog/repair.rb
@@ -50,7 +50,9 @@ module Pocolog
             end
             reporter.finish
             true
-        rescue InvalidFile
+        rescue Interrupt
+            raise
+        rescue StandardError
             reporter.finish
             remaining = File.stat(path).size - current_pos
             reporter.error "#{path}: broken at position #{current_pos} "\


### PR DESCRIPTION
Not catching other error types meant that they would raise instead of truncating the file. Breaking the file is preferable than failing to repair.