### PR TITLE
chore: minor optimization

### DIFF
--- a/lib/pocolog/block_stream.rb
+++ b/lib/pocolog/block_stream.rb
@@ -381,7 +381,7 @@ module Pocolog
                 end
 
                 rt_sec, rt_usec, lg_sec, lg_usec, data_size, compressed =
-                    raw_data.unpack("VVVVVC")
+                    raw_data.unpack("V5C")
                 new(rt_sec * 1_000_000 + rt_usec,
                     lg_sec * 1_000_000 + lg_usec,
                     data_size,


### PR DESCRIPTION
For reference:

```
     unpack repeated      4.886M (± 0.2%) i/s  (204.67 ns/i) -     24.878M in   5.091856s
         unpack star      3.312M (± 0.1%) i/s  (301.94 ns/i) -     16.773M in   5.064578s
        unpack count      5.063M (± 0.2%) i/s  (197.52 ns/i) -     25.332M in   5.003643s
```

where 'repeated' is VVVVVC, 'star' is V* and then C (two string slices) and 'count' is V5C.